### PR TITLE
Set up code climate coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ before_install:
   - ls -la
   - echo ${PATH}
   - python --version
-install: sh ci/travis/install.sh
+install: bash ci/travis/install.sh
 script: python setup.py test
-after_success: sh ci/travis/after_success.sh
+after_success: bash ci/travis/after_success.sh

--- a/ci/travis/after_success.sh
+++ b/ci/travis/after_success.sh
@@ -3,6 +3,6 @@
 set -e
 set -x
 
-if [ "$CODECLIMATE_COVERAGE_REPORT" == "true" ]; then
-	codeclimate-test-reporter --token $CODECLIMATE_COVERAGE_TOKEN
+if [ "${CODECLIMATE_COVERAGE_REPORT}" == "true" ]; then
+	codeclimate-test-reporter --token ${CODECLIMATE_COVERAGE_TOKEN}
 fi

--- a/ci/travis/after_success.sh
+++ b/ci/travis/after_success.sh
@@ -4,5 +4,6 @@ set -e
 set -x
 
 if [ "${CODECLIMATE_COVERAGE_REPORT}" == "true" ]; then
+	set +x
 	codeclimate-test-reporter --token ${CODECLIMATE_COVERAGE_TOKEN}
 fi


### PR DESCRIPTION
Send coverage report to code climate via travis CI build environment.
See [Setting Up Test Coverage](https://docs.codeclimate.com/docs/setting-up-test-coverage).