### PR TITLE
Fix link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,6 @@
    :alt: Issue Count
 
 
-
-
 mafipy
 ======
 
@@ -31,7 +29,7 @@ Relateded
 
 document
 ============
+`API document`_
 
-[API document](https://i05nagai.github.io/mafipy_docs/html/).
-
+.. _API document: `https://i05nagai.github.io/mafipy_docs/html/`
 


### PR DESCRIPTION
The link to API document is written in markdown but `README.rst` is restructuredText.