### PR TITLE
Fix build error in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,13 +1,12 @@
 engines:
-	pep8:
+  pep8:
     enabled: true	
-	radon: 
-		enabled: true
+  radon: 
+    enabled: true
 ratings:
   paths:
-		- "mafipy/**"
-		- "**.py"
-## other configuration excluded from example...
+    - "mafipy/**"
+    - "*.py"
 exclude_paths:
   - "examples/*"
   - "ci/*"


### PR DESCRIPTION
Here build error in[Code Climate](https://codeclimate.com/github/i05nagai/mafipy/builds/12) has not fixed yet.
Test coverage is updated because Test coverage report is sent from Travis CI which correctly works.
GPA of the repository is not updated because of the build error.