### PR TITLE
Enhance caluclation of black scholes option value

### DIFF
--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -276,6 +276,9 @@ def calc_black_scholes_put_value(
         vol,
         today=0.0):
     """calc_black_scholes_put_value
+    evaluates value of put option using put-call parity so that
+    this function calls :py:func:`calc_black_scholes_call_value`.
+    See :py:func:`calc_black_scholes_put_formula`.
 
     :param float underlying:
     :param float strike:
@@ -286,8 +289,10 @@ def calc_black_scholes_put_value(
     :return: put value.
     :rtype: float
     """
-    return calc_black_scholes_put_formula(
-        underlying, strike, rate, maturity - today, vol)
+    call_value = calc_black_scholes_call_value(
+        underlying, strike, rate, maturity, vol, today)
+    discount = math.exp(-rate * (maturity - today))
+    return call_value - (underlying - strike * discount)
 
 
 def black_scholes_call_value_fprime_by_strike(

--- a/mafipy/tests/test_analytic_formula.py
+++ b/mafipy/tests/test_analytic_formula.py
@@ -190,11 +190,13 @@ class TestAnalytic(object):
         ])
     def test_calc_black_scholes_put_value(
             self, underlying, strike, rate, maturity, vol, today):
-        expect = target.calc_black_scholes_put_formula(
-            underlying, strike, rate, maturity - today, vol)
+        call_value = target.calc_black_scholes_call_value(
+            underlying, strike, rate, maturity, vol, today)
+        discount = math.exp(-rate * (maturity - today))
+        expect = call_value - (underlying - discount * strike)
         actual = target.calc_black_scholes_put_value(
             underlying, strike, rate, maturity, vol, today)
-        assert actual == approx(expect)
+        assert expect == approx(actual)
 
     @pytest.mark.parametrize(
         "underlying, strike, rate, maturity, vol, today",


### PR DESCRIPTION
In some cases (dependends on values of parameters), value of call option under black scholes model is not calculated raising exception.
Following cases could be computable because of positivity of black scholes model.

* strike < 0, underlying > 0
	* return value of forward contraction with same stirke and same maturity.
* strike > 0, underlying < 0
	* returns 0