### PR TITLE
Add test of put-call parity under black scholes

### DIFF
--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -247,23 +247,24 @@ def calc_black_scholes_call_value(
     :rtype: float
     """
     assert(vol >= 0.0)
+    time = maturity - today
     # option is expired
-    if maturity < 0.0 or np.isclose(maturity, 0.0):
+    if time < 0.0 or np.isclose(time, 0.0):
         return 0.0
     # never below strike
     elif strike < 0.0 and underlying > 0.0:
-        return underlying - math.exp(-rate * maturity) * strike
+        return underlying - math.exp(-rate * time) * strike
     # never beyond strike
     elif strike > 0.0 and underlying < 0.0:
         return 0.0
     elif underlying < 0.0:
         # max(S - K, 0) = (S - K) + max(-(S - K), 0)
         value = calc_black_scholes_call_formula(
-            -underlying, -strike, rate, maturity - today, vol)
+            -underlying, -strike, rate, time, vol)
         return (underlying - strike) + value
 
     return calc_black_scholes_call_formula(
-        underlying, strike, rate, maturity - today, vol)
+        underlying, strike, rate, time, vol)
 
 
 def calc_black_scholes_put_value(
@@ -287,9 +288,14 @@ def calc_black_scholes_put_value(
     :return: put value.
     :rtype: float
     """
+    time = maturity - today
+    # option is expired
+    if time < 0.0 or np.isclose(time, 0.0):
+        return 0.0
+
     call_value = calc_black_scholes_call_value(
         underlying, strike, rate, maturity, vol, today)
-    discount = math.exp(-rate * (maturity - today))
+    discount = math.exp(-rate * time)
     return call_value - (underlying - strike * discount)
 
 

--- a/mafipy/tests/test_analytic_formula.py
+++ b/mafipy/tests/test_analytic_formula.py
@@ -7,6 +7,7 @@ from pytest import approx
 import numpy as np
 import mafipy.analytic_formula as target
 import mafipy.math_formula
+import mafipy.tests.util as util
 import math
 import pytest
 import scipy.stats
@@ -632,3 +633,45 @@ class TestBlackScholesPricerHelper:
         actual_func = self.target_class.make_put_wrt_strike(
             underlying, rate, maturity, vol, today)
         assert type(expect_func) == type(actual_func)
+
+
+class TestModelAnalyticFormula(object):
+
+    # before all tests starts
+    @classmethod
+    def setup_class(cls):
+        pass
+
+    # after all tests finish
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    # before each test start
+    def setup(self):
+        pass
+
+    # after each test finish
+    def teardown(self):
+        pass
+
+    @pytest.mark.parametrize(
+        "underlying, strike, rate, maturity, vol, today", [
+            util.get_real(6)
+        ])
+    def test_put_call_parity_black_scholes(
+            self, underlying, strike, rate, maturity, vol, today):
+
+        call_value = target.calc_black_scholes_call_value(
+            underlying, strike, rate, maturity, vol, today)
+        put_value = target.calc_black_scholes_put_value(
+            underlying, strike, rate, maturity, vol, today)
+        # forward
+        time = maturity - today
+        if time < 0.0:
+            forward_value = 0.0
+        else:
+            discount = math.exp(-rate * time)
+            forward_value = underlying - discount * strike
+
+        assert forward_value == approx(call_value - put_value)


### PR DESCRIPTION
This issue adds test to check put-call parity under black scholes model in `analytic_formula`.