### PR TITLE
Ignore Line break before binary operator in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,10 @@
 engines:
   pep8:
     enabled: true	
+    checks:
+      # Line break before binary operator
+      W503:
+        enabled: false
   radon: 
     enabled: true
 ratings:


### PR DESCRIPTION
In codeclimate, GPA in python is calculated from PEP8 and radon([Cyclomatic complexity - Wikipedia](https://en.wikipedia.org/wiki/Cyclomatic_complexity)).
PEP8 warns `Line break before binary operator` (for instance [mafipy/tests/test_pricer_quanto_cms.py from i05nagai/mafipy - Code Climate](https://codeclimate.com/github/i05nagai/mafipy/mafipy/tests/test_pricer_quanto_cms.py?from_sha=f5d2768b&to_sha=dd6b915d)).
But line break **after** binary operator makes formula readable so that this issue add settings to codeclimate to ignore the warning.