### PR TITLE
Fix a example of simple qunato cms

### DIFF
--- a/examples/simple_quanto_cms.py
+++ b/examples/simple_quanto_cms.py
@@ -4,85 +4,100 @@ from mafipy import pricer_quanto_cms
 from mafipy import analytic_formula
 
 
-def main():
-    init_swap_rate = 0.04
-    rate = 0.01
-    maturity = 1.0
-    vol_swap_rate = 0.05
-    swap_rate_cdf = pricer_quanto_cms.make_cdf_black_scholes(
-        underlying=init_swap_rate,
-        rate=rate,
-        maturity=maturity,
+def linear_annuity(payoff_type):
+    if payoff_type == "call":
+        gen_payoff_params = gen_call_params
+    elif payoff_type == "bull_spread":
+        gen_payoff_params = gen_bull_spread_params
+
+    init_swap_rate = 0.018654
+    swap_annuity = 0.99
+    maturity = 2.0
+    vol_swap_rate = 0.39
+    vol_put = 0.39
+    vol_call = 0.39
+    vol_forward_fx = 0.03
+    swap_rate_cdf = pricer_quanto_cms.make_cdf_black_swaption(
+        init_swap_rate=init_swap_rate,
+        swap_annuity=swap_annuity,
+        option_maturity=maturity,
         vol=vol_swap_rate)
-    swap_rate_pdf = pricer_quanto_cms.make_pdf_black_scholes(
-        underlying=init_swap_rate,
-        rate=rate,
-        maturity=maturity,
+    swap_rate_pdf = pricer_quanto_cms.make_pdf_black_swaption(
+        init_swap_rate=init_swap_rate,
+        swap_annuity=swap_annuity,
+        option_maturity=maturity,
         vol=vol_swap_rate)
-    swap_rate_pdf_fprime = pricer_quanto_cms.make_pdf_fprime_black_scholes(
-        underlying=init_swap_rate,
-        rate=rate,
-        maturity=maturity,
+    swap_rate_pdf_fprime = pricer_quanto_cms.make_pdf_fprime_black_swaption(
+        init_swap_rate=init_swap_rate,
+        swap_annuity=swap_annuity,
+        option_maturity=maturity,
         vol=vol_swap_rate)
-    print(swap_rate_pdf_fprime(1.0))
     annuity_mapping_params = {
-        "alpha0": 1.0,
-        "alpha1": 0.9
+        "alpha0": init_swap_rate,
+        "alpha1": 1.0 / 2.0
     }
-    payoff_params = {
-        "strike": 0.04,
-        "gearing": 1.0,
-    }
+    payoff_params = gen_payoff_params()
     forward_fx_diffusion_params = {
-        "time": 1.0,
-        "vol": 0.01,
+        "time": 2.0,
+        "vol": vol_forward_fx,
         "corr": 0.1,
         "swap_rate_cdf": swap_rate_cdf,
         "swap_rate_pdf": swap_rate_pdf,
         "swap_rate_pdf_fprime": swap_rate_pdf_fprime
     }
-    call_pricer_params = {
-        "underlying": init_swap_rate,
-        "rate": rate,
-        "maturity": 1.0,
-        "vol": 0.01,
-        "today": 0.0,
+    payer_pricer_params = {
+        "init_swap_rate": init_swap_rate,
+        "swap_annuity": swap_annuity,
+        "option_maturity": 2.0,
+        "vol": vol_call,
     }
-    bs_pricer = analytic_formula.BlackScholesPricerHelper()
-    call_pricer = bs_pricer.make_call_wrt_strike(**call_pricer_params)
-    put_pricer_params = {
-        "underlying": init_swap_rate,
-        "rate": rate,
-        "maturity": 1.0,
-        "vol": 0.01,
-        "today": 0.0,
+    bs_pricer = analytic_formula.BlackSwaptionPricerHelper()
+    payer_pricer = bs_pricer.make_payers_swaption_wrt_strike(
+        **payer_pricer_params)
+    receiver_pricer_params = {
+        "init_swap_rate": init_swap_rate,
+        "swap_annuity": swap_annuity,
+        "option_maturity": 2.0,
+        "vol": vol_put
     }
-    put_pricer = bs_pricer.make_put_wrt_strike(**put_pricer_params)
-    """
-    pricer = pricer_quanto_cms.SimpleQuantoCmsPricer(
-        "linear", annuity_mapping_params,
-        "call", payoff_params,
-        forward_fx_diffusion_params,
-        call_pricer,
-        put_pricer)
-    price = pricer.eval(discount_factor, init_swap_rate,
-                        min_put_range=0.0 + 0.000000001,
-                        max_call_range=0.06)
-    """
-    discount_factor = 0.9
+    receiver_pricer = bs_pricer.make_receivers_swaption_wrt_strike(
+        **receiver_pricer_params)
+    discount_factor = 1.0
     price = pricer_quanto_cms.replicate(
         init_swap_rate,
         discount_factor,
-        call_pricer,
-        put_pricer,
-        "call",
+        payer_pricer,
+        receiver_pricer,
+        payoff_type,
         payoff_params,
         forward_fx_diffusion_params,
         "linear",
         annuity_mapping_params,
-        min_put_range=0.0 + 0.000000001,
-        max_call_range=0.060)
+        min_put_range=0.0 + 0.00001,
+        max_call_range=0.030)
     print("price:", price)
+
+
+def gen_call_params():
+    return {
+        "strike": 0.00001,
+        "gearing": 1.0,
+    }
+
+
+def gen_bull_spread_params():
+    return {
+        "lower_strike": 0.00001,
+        "upper_strike": 0.09327,
+        "gearing": 1.0 / 0.09327,
+    }
+
+
+def main():
+    print("call")
+    linear_annuity("call")
+    print("bull_spread")
+    linear_annuity("bull_spread")
 
 
 if __name__ == '__main__':

--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -1236,3 +1236,73 @@ class BlackScholesPricerHelper(object):
             maturity=maturity,
             vol=vol,
             today=today)
+
+
+class BlackSwaptionPricerHelper(object):
+    """BlackSwaptionPricerHelper
+    Helper functions to generate a function with respect to a sigle variable.
+    For instance, black formula as a function of volatility is needed to
+    evaluate market smile by implied volatility.
+    """
+
+    def make_payers_swaption_wrt_strike(
+            self,
+            init_swap_rate,
+            swap_annuity,
+            option_maturity,
+            vol):
+        """make_payers_swaption_wrt_strike
+        make function of black payer's swaption formula
+        with respect to function.
+        This function return :py:func:`black_receivers_swaption_value`
+        as funciton of a single variable.
+
+        .. math::
+
+            V_{\mathrm{payers}}(K; S, A, T, \sigma)
+                := V_{\mathrm{payers}}(S, K, A, T, \sigma)
+
+        :param float init_swap_rate:
+        :param float swap_annuity:
+        :param float option_maturity:
+        :param float vol: volatility.
+        :return: payer's swaption pricer as a function of strike.
+        :rtype: LambdaType
+        """
+        return lambda option_strike: black_payers_swaption_value(
+            init_swap_rate=init_swap_rate,
+            option_strike=option_strike,
+            swap_annuity=swap_annuity,
+            option_maturity=option_maturity,
+            vol=vol)
+
+    def make_receivers_swaption_wrt_strike(
+            self,
+            init_swap_rate,
+            swap_annuity,
+            option_maturity,
+            vol):
+        """make_put_wrt_strike
+        make function of black receiver's swaption formula
+        with respect to strike.
+        This function return :py:func:`black_receivers_swaption_value`
+        as funciton of a single variable.
+
+        .. math::
+
+            V_{\mathrm{receivers}}(K; S, A, T, \sigma)
+                := V_{\mathrm{receiver}}(S, K, A, T, \sigma)
+
+        :param float init_swap_rate:
+        :param float swap_annuity:
+        :param float option_maturity:
+        :param float vol: volatility
+        :return: receiver's swaption pricer as a function of strike.
+        :rtype: LambdaType.
+        """
+        return lambda option_strike: black_receivers_swaption_value(
+            init_swap_rate=init_swap_rate,
+            option_strike=option_strike,
+            swap_annuity=swap_annuity,
+            option_maturity=option_maturity,
+            vol=vol)

--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -614,8 +614,7 @@ def black_payers_swaption_value_fprime_by_strike(
 
     value = black_scholes_call_value_fprime_by_strike(
         init_swap_rate, option_strike, 0.0, option_maturity, vol)
-
-    return -swap_annuity * value
+    return swap_annuity * value
 
 
 def black_payers_swaption_value_fhess_by_strike(
@@ -661,7 +660,7 @@ def black_payers_swaption_value_fhess_by_strike(
     value = black_scholes_call_value_fhess_by_strike(
         init_swap_rate, option_strike, 0.0, option_maturity, vol)
 
-    return -swap_annuity * value
+    return swap_annuity * value
 
 
 def black_payers_swaption_value_third_by_strike(
@@ -711,7 +710,7 @@ def black_payers_swaption_value_third_by_strike(
     value = black_scholes_call_value_third_by_strike(
         init_swap_rate, option_strike, 0.0, option_maturity, vol)
 
-    return -swap_annuity * value
+    return swap_annuity * value
 
 
 # ----------------------------------------------------------------------------

--- a/mafipy/pricer_quanto_cms.py
+++ b/mafipy/pricer_quanto_cms.py
@@ -12,6 +12,111 @@ from . import payoff
 from . import replication
 
 
+def make_pdf_black_swaption(
+        init_swap_rate,
+        swap_annuity,
+        option_maturity,
+        vol):
+    """make_pdf_black_swaption
+    return p.d.f. of black scholes model
+
+    .. math::
+        \Phi_{S}(k) := \\frac{\partial^{2}}{\partial K^{2}} c(0, S; T, K, \sigma)
+
+    where
+    :math:`S` is `init_swap_rate`,
+    :math:`T` is `option_maturity`,
+    :math:`K` is `option_strike`,
+    :math:`\Phi_{S}(k)` is p.d.f. of :math:`S`,
+    :math:`c(0, S; T, K)` is value of call option
+    with strike :math:`K` and :math:`T` maturity at time 0.
+
+    :param float init_swap_rate:
+    :param float rate:
+    :param float maturity: non-negative.
+    :param float vol: volatility. non-negative.
+    :return: p.d.f. of call price under black scholes model
+        as a function of strike.
+    :rtype: function with strike.
+    """
+    assert(vol >= 0.0)
+
+    def pdf(option_strike):
+        return analytic_formula.black_payers_swaption_value_fhess_by_strike(
+            init_swap_rate=init_swap_rate,
+            option_strike=option_strike,
+            swap_annuity=swap_annuity,
+            option_maturity=option_maturity,
+            vol=vol)
+
+    return pdf
+
+
+def make_pdf_fprime_black_swaption(
+        init_swap_rate,
+        swap_annuity,
+        option_maturity,
+        vol):
+    """make_pdf_fprime_black_swaption
+    return first derivative of p.d.f. of black swaption.
+    See :py:func:`make_pdf_black_swaption`.
+
+    .. math::
+        \Phi_{S}^{\prime}(k)
+        := \\frac{\partial}{\partial K^{2}} c(0, S; T, K)
+
+    where
+    :math:`S` is `init_swap_rate`,
+    :math:`T` is `option_maturity`,
+    :math:`K` is `option_strike`,
+    :math:`\Phi_{S}(k)` is p.d.f. of :math:`S`,
+    :math:`c(0, S; T, K)` is value of call option
+    with strike :math:`K` and :math:`T` maturity at time 0.
+
+    :param float init_swap_rate:
+    :param float swap_annuity:
+    :param float option_maturity: non-negative.
+    :param float vol: volatility. non-negative.
+    :return: first derivative of p.d.f. of call price under black scholes model
+        as a function of strike.
+    :rtype: function
+    """
+    assert(vol >= 0.0)
+
+    def pdf_fprime(option_strike):
+        return analytic_formula.black_payers_swaption_value_third_by_strike(
+            init_swap_rate=init_swap_rate,
+            option_strike=option_strike,
+            swap_annuity=swap_annuity,
+            option_maturity=option_maturity,
+            vol=vol)
+
+    return pdf_fprime
+
+
+def make_cdf_black_swaption(
+        init_swap_rate,
+        swap_annuity,
+        option_maturity,
+        vol):
+    """make_cdf_black_swaption
+    returns c.d.f. of black swaption.
+
+    :param init_swap_rate:
+    :param swap_annuity:
+    :param option_maturity:
+    :param vol:
+    :return: distribution of call price under black scholes model
+        as a funciton of strike.
+    :rtype: function
+    """
+    assert(vol >= 0.0)
+
+    return lambda option_strike: (
+        1.0 + analytic_formula.black_payers_swaption_value_fprime_by_strike(
+            init_swap_rate, option_strike, swap_annuity, option_maturity, vol))
+
+
 def make_pdf_black_scholes(
         underlying,
         rate,

--- a/mafipy/tests/test_analytic_formula.py
+++ b/mafipy/tests/test_analytic_formula.py
@@ -856,6 +856,62 @@ class TestBlackScholesPricerHelper:
         assert type(expect_func) == type(actual_func)
 
 
+class TestBlackSwaptionPricerHelper(object):
+
+    # before all tests starts
+    @classmethod
+    def setup_class(cls):
+        pass
+
+    # after all tests finish
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    # before each test start
+    def setup(self):
+        self.target = target.BlackSwaptionPricerHelper()
+        pass
+
+    # after each test finish
+    def teardown(self):
+        pass
+
+    @pytest.mark.parametrize(
+        "init_swap_rate, swap_annuity, option_maturity, vol", [
+            (1.0, 1.0, 0.1, 1.0)
+        ])
+    def test_make_payers_swaption_strike(
+            self, init_swap_rate, swap_annuity, option_maturity, vol):
+        def expect_func(option_strike):
+            return target.black_payers_swaption_value(
+                init_swap_rate=init_swap_rate,
+                option_strike=option_strike,
+                swap_annuity=swap_annuity,
+                option_maturity=option_maturity,
+                vol=vol)
+        actual_func = self.target.make_payers_swaption_wrt_strike(
+            init_swap_rate, swap_annuity, option_maturity, vol)
+        assert type(expect_func) == type(actual_func)
+
+    @pytest.mark.parametrize(
+        "init_swap_rate, swap_annuity, option_maturity, vol", [
+            (1.0, 1.0, 0.1, 1.0)
+        ])
+    def test_make_receivers_swaption_wrt_strike(
+            self, init_swap_rate, swap_annuity, option_maturity, vol):
+        def expect_func(option_strike):
+            return target.black_receivers_swaption_value(
+                init_swap_rate=init_swap_rate,
+                option_strike=option_strike,
+                swap_annuity=swap_annuity,
+                option_maturity=option_maturity,
+                vol=vol)
+        actual_func = self.target.make_receivers_swaption_wrt_strike(
+            init_swap_rate, swap_annuity, option_maturity, vol)
+        assert type(expect_func) == type(actual_func)
+
+
 class TestModelAnalyticFormula(object):
 
     # before all tests starts

--- a/mafipy/tests/test_analytic_formula.py
+++ b/mafipy/tests/test_analytic_formula.py
@@ -315,9 +315,9 @@ class TestAnalytic(object):
                 underlying, strike, rate, maturity, vol)
             assert expect == approx(actual)
 
-    # ----------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Black payers/recievers swaption
-    # ----------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     @pytest.mark.parametrize(
         "init_swap_rate, option_strike, swap_annuity, option_maturity, vol",
         [
@@ -437,7 +437,7 @@ class TestAnalytic(object):
             # because it is a bit complicated to generate test cases
             value = target.black_scholes_call_value_fprime_by_strike(
                 init_swap_rate, option_strike, 0.0, option_maturity, vol)
-            expect = -swap_annuity * value
+            expect = swap_annuity * value
 
         actual = target.black_payers_swaption_value_fprime_by_strike(
             init_swap_rate,
@@ -480,7 +480,7 @@ class TestAnalytic(object):
             # because it is a bit complicated to generate test cases
             value = target.black_scholes_call_value_fhess_by_strike(
                 init_swap_rate, option_strike, 0.0, option_maturity, vol)
-            expect = -swap_annuity * value
+            expect = swap_annuity * value
 
         actual = target.black_payers_swaption_value_fhess_by_strike(
             init_swap_rate,
@@ -523,7 +523,7 @@ class TestAnalytic(object):
             # because it is a bit complicated to generate test cases
             value = target.black_scholes_call_value_third_by_strike(
                 init_swap_rate, option_strike, 0.0, option_maturity, vol)
-            expect = -swap_annuity * value
+            expect = swap_annuity * value
 
         actual = target.black_payers_swaption_value_third_by_strike(
             init_swap_rate,
@@ -533,9 +533,9 @@ class TestAnalytic(object):
             vol)
         assert expect == approx(actual)
 
-    # ----------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Black scholes greeks
-    # ----------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     @pytest.mark.parametrize(
         "underlying, strike, rate, maturity, vol, today",
         [

--- a/mafipy/tests/test_pricer_quanto_cms.py
+++ b/mafipy/tests/test_pricer_quanto_cms.py
@@ -36,6 +36,90 @@ class TestPricerQuantoCms(object):
     def teardown(self):
         pass
 
+    # -------------------------------------------------------------------------
+    # Black swaption model
+    # -------------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "init_swap_rate, strike, swap_annuity, option_maturity, vol", [
+            # vol < 0 raise AssertionError
+            (2.0, 1.0, 1.0, 1.0, -1.0),
+            # otherwise
+            (2.0, 1.0, 1.0, 1.0, 1.0),
+        ])
+    def test_make_pdf_black_swaption(self,
+                                     init_swap_rate,
+                                     strike,
+                                     swap_annuity,
+                                     option_maturity,
+                                     vol):
+        # raise AssertionError
+        if vol < 0.0:
+            with pytest.raises(AssertionError):
+                actual = target.make_pdf_black_swaption(
+                    init_swap_rate, swap_annuity, option_maturity, vol)
+        else:
+            af = analytic_formula
+            expect = af.black_payers_swaption_value_fhess_by_strike(
+                init_swap_rate, strike, swap_annuity, option_maturity, vol)
+            actual = target.make_pdf_black_swaption(
+                init_swap_rate, swap_annuity, option_maturity, vol)(strike)
+            assert expect == approx(actual)
+
+    @pytest.mark.parametrize(
+        "init_swap_rate, strike, swap_annuity, option_maturity, vol", [
+            # vol < 0 raise AssertionError
+            (2.0, 1.0, 1.0, 1.0, -1.0),
+            # otherwise
+            (2.0, 1.0, 1.0, 1.0, 1.0),
+        ])
+    def test_make_pdf_fprime_black_swaption(self,
+                                            init_swap_rate,
+                                            strike,
+                                            swap_annuity,
+                                            option_maturity,
+                                            vol):
+        # raise AssertionError
+        if vol < 0.0:
+            with pytest.raises(AssertionError):
+                actual = target.make_pdf_fprime_black_swaption(
+                    init_swap_rate, swap_annuity, option_maturity, vol)
+        else:
+            af = analytic_formula
+            expect = af.black_payers_swaption_value_third_by_strike(
+                init_swap_rate, strike, swap_annuity, option_maturity, vol)
+            actual = target.make_pdf_fprime_black_swaption(
+                init_swap_rate, swap_annuity, option_maturity, vol)(strike)
+            assert expect == approx(actual)
+
+    @pytest.mark.parametrize(
+        "init_swap_rate, strike, swap_annuity, option_maturity, vol", [
+            # vol < 0 raise AssertionError
+            (2.0, 1.0, 1.0, 1.0, -1.0),
+            # otherwise
+            (2.0, 1.0, 1.0, 1.0, 1.0),
+        ])
+    def test_make_cdf_black_swaption(self,
+                                     init_swap_rate,
+                                     strike,
+                                     swap_annuity,
+                                     option_maturity,
+                                     vol):
+        # raise AssertionError
+        if vol < 0.0:
+            with pytest.raises(AssertionError):
+                actual = target.make_cdf_black_swaption(
+                    init_swap_rate, swap_annuity, option_maturity, vol)
+        else:
+            af = analytic_formula
+            expect = (1.0 + af.black_payers_swaption_value_fprime_by_strike(
+                init_swap_rate, strike, swap_annuity, option_maturity, vol))
+            actual = target.make_cdf_black_swaption(
+                init_swap_rate, swap_annuity, option_maturity, vol)(strike)
+            assert expect == approx(actual)
+
+    # -------------------------------------------------------------------------
+    # Black scholes model
+    # -------------------------------------------------------------------------
     @pytest.mark.parametrize("underlying, strike, rate, maturity, vol, expect", [
         # maturity < 0 raise AssertionError
         (2.0, 1.0, 1.0, -1.0, 1.0, 1.0),


### PR DESCRIPTION
This issue fix the example of pricing simple quanto cms with replication method.
Underlying swap rate should follow and price under black swaption model but the swap rate are currently considered black scholes model.
Although both the formulae derived from black swaption model and black scholes model could be equal if we give the appropriate value of parameters such as risk free rate and annuity of swap, it is not convinent(user-friendly) to use the functions derivied from black scholes model instead of the functions derived from black swaption model.

We add functions to black swapton model to correspond to the functions to black scholes model.
Then we replace the functions in the example of quanto cms.