### PR TITLE
Fix p.d.f. of black swaption model

### DIFF
--- a/examples/simple_quanto_cms.py
+++ b/examples/simple_quanto_cms.py
@@ -11,7 +11,7 @@ def linear_annuity(payoff_type):
         gen_payoff_params = gen_bull_spread_params
 
     init_swap_rate = 0.018654
-    swap_annuity = 0.99
+    swap_annuity = 2.004720
     maturity = 2.0
     vol_swap_rate = 0.39
     vol_put = 0.39
@@ -33,7 +33,7 @@ def linear_annuity(payoff_type):
         option_maturity=maturity,
         vol=vol_swap_rate)
     annuity_mapping_params = {
-        "alpha0": init_swap_rate,
+        "alpha0": (0.97990869 / swap_annuity - 0.5) / swap_annuity - 0.5,
         "alpha1": 1.0 / 2.0
     }
     payoff_params = gen_payoff_params()
@@ -73,14 +73,14 @@ def linear_annuity(payoff_type):
         forward_fx_diffusion_params,
         "linear",
         annuity_mapping_params,
-        min_put_range=0.0 + 0.00001,
-        max_call_range=0.030)
+        min_put_range=0.0002,
+        max_call_range=0.050)
     print("price:", price)
 
 
 def gen_call_params():
     return {
-        "strike": 0.00001,
+        "strike": 0.0001,
         "gearing": 1.0,
     }
 

--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -593,6 +593,13 @@ def black_payers_swaption_value_fprime_by_strike(
     :rtype: float
 
     :raises AssertionError: if volatility is not positive.
+
+    .. note::
+        Roughly speaking, this function calculates :math:`A(t) \Phi(d)`.
+        Percentile of probability 1 is infinity so that
+        assumption that annuity is equal to 1 is not good assumption
+        beacuse of :math:`\Phi(d)` returns 1 in some cases.
+
     """
     assert(vol > 0.0)
     # option is expired

--- a/mafipy/pricer_quanto_cms.py
+++ b/mafipy/pricer_quanto_cms.py
@@ -52,7 +52,7 @@ def make_pdf_black_swaption(
         return analytic_formula.black_payers_swaption_value_fhess_by_strike(
             init_swap_rate=init_swap_rate,
             option_strike=option_strike,
-            swap_annuity=swap_annuity,
+            swap_annuity=1.0,
             option_maturity=option_maturity,
             vol=vol)
 
@@ -98,7 +98,7 @@ def make_pdf_fprime_black_swaption(
         return analytic_formula.black_payers_swaption_value_third_by_strike(
             init_swap_rate=init_swap_rate,
             option_strike=option_strike,
-            swap_annuity=swap_annuity,
+            swap_annuity=1.0,
             option_maturity=option_maturity,
             vol=vol)
 
@@ -127,7 +127,7 @@ def make_cdf_black_swaption(
 
     return lambda option_strike: (
         1.0 + analytic_formula.black_payers_swaption_value_fprime_by_strike(
-            init_swap_rate, option_strike, swap_annuity, option_maturity, vol))
+            init_swap_rate, option_strike, 1.0, option_maturity, vol))
 
 
 # -----------------------------------------------------------------------------

--- a/mafipy/tests/test_pricer_quanto_cms.py
+++ b/mafipy/tests/test_pricer_quanto_cms.py
@@ -42,9 +42,9 @@ class TestPricerQuantoCms(object):
     @pytest.mark.parametrize(
         "init_swap_rate, strike, swap_annuity, option_maturity, vol", [
             # vol < 0 raise AssertionError
-            (2.0, 1.0, 1.0, 1.0, -1.0),
+            (2.0, 1.0, 3.0, 1.0, -1.0),
             # otherwise
-            (2.0, 1.0, 1.0, 1.0, 1.0),
+            (2.0, 1.0, 3.0, 1.0, 1.0),
         ])
     def test_make_pdf_black_swaption(self,
                                      init_swap_rate,
@@ -60,7 +60,7 @@ class TestPricerQuantoCms(object):
         else:
             af = analytic_formula
             expect = af.black_payers_swaption_value_fhess_by_strike(
-                init_swap_rate, strike, swap_annuity, option_maturity, vol)
+                init_swap_rate, strike, 1.0, option_maturity, vol)
             actual = target.make_pdf_black_swaption(
                 init_swap_rate, swap_annuity, option_maturity, vol)(strike)
             assert expect == approx(actual)
@@ -68,9 +68,9 @@ class TestPricerQuantoCms(object):
     @pytest.mark.parametrize(
         "init_swap_rate, strike, swap_annuity, option_maturity, vol", [
             # vol < 0 raise AssertionError
-            (2.0, 1.0, 1.0, 1.0, -1.0),
+            (2.0, 1.0, 3.0, 1.0, -1.0),
             # otherwise
-            (2.0, 1.0, 1.0, 1.0, 1.0),
+            (2.0, 1.0, 3.0, 1.0, 1.0),
         ])
     def test_make_pdf_fprime_black_swaption(self,
                                             init_swap_rate,
@@ -86,7 +86,7 @@ class TestPricerQuantoCms(object):
         else:
             af = analytic_formula
             expect = af.black_payers_swaption_value_third_by_strike(
-                init_swap_rate, strike, swap_annuity, option_maturity, vol)
+                init_swap_rate, strike, 1.0, option_maturity, vol)
             actual = target.make_pdf_fprime_black_swaption(
                 init_swap_rate, swap_annuity, option_maturity, vol)(strike)
             assert expect == approx(actual)
@@ -94,9 +94,9 @@ class TestPricerQuantoCms(object):
     @pytest.mark.parametrize(
         "init_swap_rate, strike, swap_annuity, option_maturity, vol", [
             # vol < 0 raise AssertionError
-            (2.0, 1.0, 1.0, 1.0, -1.0),
+            (2.0, 1.0, 3.0, 1.0, -1.0),
             # otherwise
-            (2.0, 1.0, 1.0, 1.0, 1.0),
+            (2.0, 1.0, 3.0, 1.0, 1.0),
         ])
     def test_make_cdf_black_swaption(self,
                                      init_swap_rate,
@@ -112,7 +112,7 @@ class TestPricerQuantoCms(object):
         else:
             af = analytic_formula
             expect = (1.0 + af.black_payers_swaption_value_fprime_by_strike(
-                init_swap_rate, strike, swap_annuity, option_maturity, vol))
+                init_swap_rate, strike, 1.0, option_maturity, vol))
             actual = target.make_cdf_black_swaption(
                 init_swap_rate, swap_annuity, option_maturity, vol)(strike)
             assert expect == approx(actual)


### PR DESCRIPTION
p.d.f. and c.d.f. of black swaption model in `pricer_quanto_cms` is not correct.
The p.d.f. is second derivative of black swaption formula in case that annuity is equal to 1.