### PR TITLE
Supports payment in domestic currency and referencing foreign currency

### DIFF
--- a/examples/simple_quanto_cms.py
+++ b/examples/simple_quanto_cms.py
@@ -40,7 +40,8 @@ def linear_annuity(payoff_type, payoff_params, quanto_cms_params):
         "corr": corr_forward_fx,
         "swap_rate_cdf": swap_rate_cdf,
         "swap_rate_pdf": swap_rate_pdf,
-        "swap_rate_pdf_fprime": swap_rate_pdf_fprime
+        "swap_rate_pdf_fprime": swap_rate_pdf_fprime,
+        "is_inverse": True
     }
     payer_pricer_params = {
         "init_swap_rate": init_swap_rate,
@@ -110,7 +111,7 @@ def gen_cms_params_atm():
         "vol_put": 0.39,
         "vol_call": 0.39,
         "vol_forward_fx": 0.03,
-        "corr_forward_fx": 0.3,
+        "corr_forward_fx": 0.0,
     }
 
 

--- a/mafipy/tests/util.py
+++ b/mafipy/tests/util.py
@@ -7,3 +7,18 @@ def get_real(size=1, min_range=0.0, max_range=1.0):
 
 def get_real_t(size=1, min_range=0.0, max_range=1.0):
     return tuple(get_real(size, min_range, max_range))
+
+
+def get(min_range=0.0, max_range=1.0):
+    return random.uniform(min_range, max_range)
+
+
+def _to_bool(value):
+    if value > 0.5:
+        return True
+    else:
+        return False
+
+
+def get_bool(size=1):
+    return map(_to_bool, get_real(size))

--- a/mafipy/tests/util.py
+++ b/mafipy/tests/util.py
@@ -21,4 +21,4 @@ def _to_bool(value):
 
 
 def get_bool(size=1):
-    return map(_to_bool, get_real(size))
+    return [_to_bool(v) for v in get_real(size)]


### PR DESCRIPTION
Pricer of quanto cms currently supports payment in foreign currency and referencing domestic index.
This issues introduces pyament in domestic currency and referencing foreign currency.