### PR TITLE
Enhance pricer of black scholes call and put

### DIFF
--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -301,6 +301,10 @@ def calc_black_scholes_put_value(
     # option is expired
     if time < 0.0 or np.isclose(time, 0.0):
         return 0.0
+    elif np.isclose(strike, 0.0) and underlying > 0.0:
+        return 0.0
+    elif np.isclose(strike, 0.0) and underlying < 0.0:
+        return underlying * math.exp(-rate * today)
 
     call_value = calc_black_scholes_call_value(
         underlying, strike, rate, maturity, vol, today)

--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -254,6 +254,12 @@ def calc_black_scholes_call_value(
     # option is expired
     if time < 0.0 or np.isclose(time, 0.0):
         return 0.0
+    elif np.isclose(underlying, 0.0):
+        return math.exp(-rate * time) * max(-strike, 0.0)
+    elif np.isclose(strike, 0.0) and underlying > 0.0:
+        return math.exp(-rate * today) * underlying
+    elif np.isclose(strike, 0.0) and underlying < 0.0:
+        return 0.0
     # never below strike
     elif strike < 0.0 and underlying > 0.0:
         return underlying - math.exp(-rate * time) * strike

--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -30,7 +30,7 @@ def _is_d1_or_d2_infinity(underlying, strike, vol):
 def func_d1(underlying, strike, rate, maturity, vol):
     """func_d1
     calculate :math:`d_{1}` in black scholes formula.
-    See :py:func:`calc_black_scholes_call_formula`.
+    See :py:func:`black_scholes_call_formula`.
 
     :param float underlying: underlying/strike must be non-negative.
     :param float strike: underlying/strike must be non-negative.
@@ -52,7 +52,7 @@ def func_d1(underlying, strike, rate, maturity, vol):
 def func_d2(underlying, strike, rate, maturity, vol):
     """func_d2
     calculate :math:`d_{2}` in black scholes formula.
-    See :py:func:`calc_black_scholes_call_formula`.
+    See :py:func:`black_scholes_call_formula`.
 
     :param float underlying: underlying/strike must be non-negative.
     :param float strike: underlying/strike must be non-negative.
@@ -127,8 +127,8 @@ def d_fhess_by_strike(underlying, strike, rate, maturity, vol):
     return 1.0 / (math.sqrt(maturity) * vol * strike * strike)
 
 
-def calc_black_scholes_call_formula(underlying, strike, rate, maturity, vol):
-    """calc_black_scholes_call_formula
+def black_scholes_call_formula(underlying, strike, rate, maturity, vol):
+    """black_scholes_call_formula
     calculate well known black scholes formula for call option.
 
     .. math::
@@ -171,8 +171,8 @@ def calc_black_scholes_call_formula(underlying, strike, rate, maturity, vol):
             - strike * math.exp(-rate * maturity) * scipy.special.ndtr(d2))
 
 
-def calc_black_scholes_put_formula(underlying, strike, rate, maturity, vol):
-    """calc_black_scholes_put_formula
+def black_scholes_put_formula(underlying, strike, rate, maturity, vol):
+    """black_scholes_put_formula
     calculate well known black scholes formula for put option.
     Here value of put option is calculated by put-call parity.
 
@@ -196,7 +196,7 @@ def calc_black_scholes_put_formula(underlying, strike, rate, maturity, vol):
     :math:`\sigma` is vol.
 
     :math:`c(\cdot)` is calculated
-    by :py:func:`calc_black_scholes_call_formula`.
+    by :py:func:`black_scholes_call_formula`.
 
     :param float underlying: value of underlying.
     :param float strike: strike of put option.
@@ -206,23 +206,23 @@ def calc_black_scholes_put_formula(underlying, strike, rate, maturity, vol):
     :return: put value.
     :rtype: float
     """
-    call_value = calc_black_scholes_call_formula(
+    call_value = black_scholes_call_formula(
         underlying, strike, rate, maturity, vol)
     discount = math.exp(-rate * maturity)
     return call_value - (underlying - strike * discount)
 
 
-def calc_black_scholes_call_value(
+def black_scholes_call_value(
         underlying,
         strike,
         rate,
         maturity,
         vol,
         today=0.0):
-    """calc_black_scholes_call_value
+    """black_scholes_call_value
     calculate call value in the case of today is not zero.
     (`maturity` - `today`) is treated as time to expiry.
-    See :py:func:`calc_black_scholes_call_formula`.
+    See :py:func:`black_scholes_call_formula`.
 
     * case :math:`S > 0, K < 0`
 
@@ -268,25 +268,25 @@ def calc_black_scholes_call_value(
         return 0.0
     elif underlying < 0.0:
         # max(S - K, 0) = (S - K) + max(-(S - K), 0)
-        value = calc_black_scholes_call_formula(
+        value = black_scholes_call_formula(
             -underlying, -strike, rate, time, vol)
         return (underlying - strike) + value
 
-    return calc_black_scholes_call_formula(
+    return black_scholes_call_formula(
         underlying, strike, rate, time, vol)
 
 
-def calc_black_scholes_put_value(
+def black_scholes_put_value(
         underlying,
         strike,
         rate,
         maturity,
         vol,
         today=0.0):
-    """calc_black_scholes_put_value
+    """black_scholes_put_value
     evaluates value of put option using put-call parity so that
-    this function calls :py:func:`calc_black_scholes_call_value`.
-    See :py:func:`calc_black_scholes_put_formula`.
+    this function calls :py:func:`black_scholes_call_value`.
+    See :py:func:`black_scholes_put_formula`.
 
     :param float underlying:
     :param float strike:
@@ -306,7 +306,7 @@ def calc_black_scholes_put_value(
     elif np.isclose(strike, 0.0) and underlying < 0.0:
         return underlying * math.exp(-rate * today)
 
-    call_value = calc_black_scholes_call_value(
+    call_value = black_scholes_call_value(
         underlying, strike, rate, maturity, vol, today)
     discount = math.exp(-rate * time)
     return call_value - (underlying - strike * discount)
@@ -321,7 +321,7 @@ def black_scholes_call_value_fprime_by_strike(
     """black_scholes_call_value_fprime_by_strike
     First derivative of value of call option with respect to strike
     under black scholes model.
-    See :py:func:`calc_black_scholes_call_formula`.
+    See :py:func:`black_scholes_call_formula`.
 
     .. math::
         \\frac{\partial }{\partial K} c(K; S, r, T, \sigma)
@@ -334,7 +334,7 @@ def black_scholes_call_value_fprime_by_strike(
     :math:`T` is maturity,
     :math:`\sigma` is vol,
     :math:`d_{1}, d_{2}` is defined
-    in :py:func:`calc_black_scholes_call_formula`,
+    in :py:func:`black_scholes_call_formula`,
     :math:`\Phi(\cdot)` is c.d.f. of standard normal distribution,
     :math:`\phi(\cdot)` is p.d.f. of standard normal distribution.
 
@@ -364,7 +364,7 @@ def black_scholes_call_value_fhess_by_strike(
     """black_scholes_call_value_fhess_by_strike
     Second derivative of value of call option with respect to strike
     under black scholes model.
-    See :py:func:`calc_black_scholes_call_formula`
+    See :py:func:`black_scholes_call_formula`
     and :py:func:`black_scholes_call_value_fprime_by_strike`.
 
     .. math::
@@ -382,7 +382,7 @@ def black_scholes_call_value_fhess_by_strike(
     :math:`T` is maturity,
     :math:`\sigma` is vol,
     :math:`d_{1}, d_{2}` is defined
-    in :py:func:`calc_black_scholes_call_formula`,
+    in :py:func:`black_scholes_call_formula`,
     :math:`\Phi(\cdot)` is c.d.f. of standard normal distribution,
     :math:`\phi(\cdot)` is p.d.f. of standard normal distribution.
 
@@ -426,7 +426,7 @@ def black_scholes_call_value_third_by_strike(
     """black_scholes_call_value_third_by_strike
     Third derivative of value of call option with respect to strike
     under black scholes model.
-    See :py:func:`calc_black_scholes_call_formula`
+    See :py:func:`black_scholes_call_formula`
     and :py:func:`black_scholes_call_value_fprime_by_strike`,
     and :py:func:`black_scholes_call_value_fhess_by_strike`.
 
@@ -448,7 +448,7 @@ def black_scholes_call_value_third_by_strike(
     :math:`T` is maturity,
     :math:`\sigma` is vol,
     :math:`d_{1}, d_{2}` is defined
-    in :py:func:`calc_black_scholes_call_formula`,
+    in :py:func:`black_scholes_call_formula`,
     :math:`\Phi(\cdot)` is c.d.f. of standard normal distribution,
     :math:`\phi(\cdot)` is p.d.f. of standard normal distribution.
 
@@ -530,7 +530,7 @@ def black_payers_swaption_value(
     :raises AssertionError: if volatility is not positive.
     """
     assert(vol > 0.0)
-    option_value = calc_black_scholes_call_value(
+    option_value = black_scholes_call_value(
         init_swap_rate, option_strike, 0.0, option_maturity, vol)
     return swap_annuity * option_value
 
@@ -568,7 +568,7 @@ def black_receivers_swaption_value(
     :raises AssertionError: if volatility is not positive.
     """
     assert(vol > 0.0)
-    option_value = calc_black_scholes_put_value(
+    option_value = black_scholes_put_value(
         init_swap_rate, option_strike, 0.0, option_maturity, vol)
     return swap_annuity * option_value
 
@@ -788,7 +788,7 @@ def black_scholes_call_gamma(
     :math:`d_{1}` is defined in
     :py:func:`func_d1`.
 
-    See :py:func:`calc_black_scholes_call_value`.
+    See :py:func:`black_scholes_call_value`.
 
     :param float underlying:
     :param float strike:
@@ -828,7 +828,7 @@ def black_scholes_call_vega(
     :math:`d_{1}` is defined in
     :py:func:`func_d1`.
 
-    See :py:func:`calc_black_scholes_call_value`.
+    See :py:func:`black_scholes_call_value`.
 
     :param float underlying:
     :param float strike:
@@ -872,7 +872,7 @@ def black_scholes_call_theta(
     :math:`d_{1}` is defined in
     :py:func:`func_d1`.
 
-    See :py:func:`calc_black_scholes_call_value`.
+    See :py:func:`black_scholes_call_value`.
 
     :param float underlying:
     :param float strike:
@@ -919,7 +919,7 @@ def black_scholes_call_rho(
     :math:`d_{2}` is defined in
     :py:func:`func_d2`.
 
-    See :py:func:`calc_black_scholes_call_value`.
+    See :py:func:`black_scholes_call_value`.
 
     :param float underlying:
     :param float strike:
@@ -1193,7 +1193,7 @@ class BlackScholesPricerHelper(object):
             today=0.0):
         """make_call_wrt_strike
         make function of black shcoles call formula with respect to function.
-        This function return :py:func:`calc_black_scholes_call_value`
+        This function return :py:func:`black_scholes_call_value`
         as funciton of a single variable.
 
         .. math::
@@ -1208,7 +1208,7 @@ class BlackScholesPricerHelper(object):
         :return: call option pricer as a function of strike.
         :rtype: LambdaType
         """
-        return lambda strike: calc_black_scholes_call_value(
+        return lambda strike: black_scholes_call_value(
             underlying=underlying,
             strike=strike,
             rate=rate,
@@ -1225,7 +1225,7 @@ class BlackScholesPricerHelper(object):
             today=0.0):
         """make_put_wrt_strike
         make function of black shcoles put formula with respect to function.
-        This function return :py:func:`calc_black_scholes_put_value`
+        This function return :py:func:`black_scholes_put_value`
         as funciton of a single variable.
 
         .. math::
@@ -1240,7 +1240,7 @@ class BlackScholesPricerHelper(object):
         :return: put option pricer as a function of strike.
         :rtype: LambdaType.
         """
-        return lambda strike: calc_black_scholes_put_value(
+        return lambda strike: black_scholes_put_value(
             underlying=underlying,
             strike=strike,
             rate=rate,

--- a/mafipy/tests/test_analytic_formula.py
+++ b/mafipy/tests/test_analytic_formula.py
@@ -205,7 +205,7 @@ class TestAnalytic(object):
     @pytest.mark.parametrize(
         "underlying, strike, rate, maturity, vol, today",
         [
-            (2.0, 1.0, 1.0, 1.0, 1.0, 0.5),
+            (2.1, 1.2, 1.3, 1.4, 1.5, 0.5),
         ])
     def test_calc_black_scholes_put_value(
             self, underlying, strike, rate, maturity, vol, today):

--- a/mafipy/tests/test_analytic_formula.py
+++ b/mafipy/tests/test_analytic_formula.py
@@ -115,9 +115,9 @@ class TestAnalytic(object):
             # underlying < strike
             (1.0, 2.0, 1.0, 1.0, 1.0, 0.478587969669),
         ])
-    def test_calc_black_scholes_call_formula(
+    def test_black_scholes_call_formula(
             self, underlying, strike, rate, maturity, vol, expect):
-        actual = target.calc_black_scholes_call_formula(
+        actual = target.black_scholes_call_formula(
             underlying, strike, rate, maturity, vol)
         assert actual == approx(expect)
 
@@ -127,13 +127,13 @@ class TestAnalytic(object):
             # underlying > strike
             (2.0, 1.0, 1.0, 1.0, 1.0),
         ])
-    def test_calc_black_scholes_put_formula(
+    def test_black_scholes_put_formula(
             self, underlying, strike, rate, maturity, vol):
-        call_value = target.calc_black_scholes_call_formula(
+        call_value = target.black_scholes_call_formula(
             underlying, strike, rate, maturity, vol)
         discount = math.exp(-rate * maturity)
         expect = call_value - (underlying - strike * discount)
-        actual = target.calc_black_scholes_put_formula(
+        actual = target.black_scholes_put_formula(
             underlying, strike, rate, maturity, vol)
         assert actual == approx(expect)
 
@@ -161,15 +161,15 @@ class TestAnalytic(object):
             # today > 0
             (2.0, 1.0, 1.0, 1.0, -1.0, 1.0),
         ])
-    def test_calc_black_scholes_call_value(
+    def test_black_scholes_call_value(
             self, underlying, strike, rate, maturity, vol, today):
         time = maturity - today
         if vol <= 0.0:
             with pytest.raises(AssertionError):
-                actual = target.calc_black_scholes_call_value(
+                actual = target.black_scholes_call_value(
                     underlying, strike, rate, maturity, vol, today)
         else:
-            actual = target.calc_black_scholes_call_value(
+            actual = target.black_scholes_call_value(
                 underlying, strike, rate, maturity, vol, today)
             if maturity < 0 or np.isclose(maturity, 0.0):
                 expect = 0.0
@@ -198,7 +198,7 @@ class TestAnalytic(object):
                 expect = 0.0
                 assert expect == approx(actual)
             else:
-                expect = target.calc_black_scholes_call_formula(
+                expect = target.black_scholes_call_formula(
                     underlying, strike, rate, time, vol)
                 assert expect == approx(actual)
 
@@ -220,14 +220,14 @@ class TestAnalytic(object):
             # otherwise
             (2.1, 1.2, 1.3, 1.4, 1.5, 0.5),
         ])
-    def test_calc_black_scholes_put_value(
+    def test_black_scholes_put_value(
             self, underlying, strike, rate, maturity, vol, today):
         time = maturity - today
-        call_value = target.calc_black_scholes_call_value(
+        call_value = target.black_scholes_call_value(
             underlying, strike, rate, maturity, vol, today)
         discount = math.exp(-rate * time)
         expect = call_value - (underlying - discount * strike)
-        actual = target.calc_black_scholes_put_value(
+        actual = target.black_scholes_put_value(
             underlying, strike, rate, maturity, vol, today)
         if time < 0.0 or np.isclose(time, 0.0):
             expect = 0.0
@@ -416,11 +416,11 @@ class TestAnalytic(object):
             expect = 0.0
         # max(S(T)-K,0) = max((-K)-(-S(T)),0)
         elif init_swap_rate < 0.0 and option_strike < 0.0:
-            option_value = target.calc_black_scholes_put_formula(
+            option_value = target.black_scholes_put_formula(
                 -init_swap_rate, -option_strike, 0.0, option_maturity, vol)
             expect = swap_annuity * option_value
         else:
-            value = target.calc_black_scholes_call_formula(
+            value = target.black_scholes_call_formula(
                 init_swap_rate, option_strike, 0.0, option_maturity, vol)
             expect = swap_annuity * value
 
@@ -476,11 +476,11 @@ class TestAnalytic(object):
             expect = swap_annuity * (option_strike - init_swap_rate)
         # max(K-S(T),0) = max((-S(T)) - (-K),0)
         elif init_swap_rate < 0.0 and option_strike < 0.0:
-            option_value = target.calc_black_scholes_call_formula(
+            option_value = target.black_scholes_call_formula(
                 -init_swap_rate, -option_strike, 0.0, option_maturity, vol)
             expect = swap_annuity * option_value
         else:
-            value = target.calc_black_scholes_put_formula(
+            value = target.black_scholes_put_formula(
                 init_swap_rate, option_strike, 0.0, option_maturity, vol)
             expect = swap_annuity * value
 
@@ -938,7 +938,7 @@ class TestBlackScholesPricerHelper:
     ])
     def test_make_call_wrt_strike(
             self, underlying, rate, maturity, vol, today):
-        expect_func = lambda strike: target.calc_black_scholes_call_value(
+        expect_func = lambda strike: target.black_scholes_call_value(
             underlying=underlying,
             strike=strike,
             rate=rate,
@@ -954,7 +954,7 @@ class TestBlackScholesPricerHelper:
     ])
     def test_make_put_wrt_strike(
             self, underlying, rate, maturity, vol, today):
-        expect_func = lambda strike: target.calc_black_scholes_put_value(
+        expect_func = lambda strike: target.black_scholes_put_value(
             underlying=underlying,
             strike=strike,
             rate=rate,
@@ -1049,9 +1049,9 @@ class TestModelAnalyticFormula(object):
     def test_put_call_parity_black_scholes(
             self, underlying, strike, rate, maturity, vol, today):
 
-        call_value = target.calc_black_scholes_call_value(
+        call_value = target.black_scholes_call_value(
             underlying, strike, rate, maturity, vol, today)
-        put_value = target.calc_black_scholes_put_value(
+        put_value = target.black_scholes_put_value(
             underlying, strike, rate, maturity, vol, today)
         # forward
         time = maturity - today

--- a/mafipy/tests/test_pricer_quanto_cms.py
+++ b/mafipy/tests/test_pricer_quanto_cms.py
@@ -1462,7 +1462,7 @@ class TestModelPricerQuantoCMS(object):
             return max(strike - payoff_strike, 0.0) * pdf(strike)
         call_value_integral = integrate.quad(
             call_integrand, payoff_strike, np.inf)[0]
-        call_value_analytic = analytic_formula.calc_black_scholes_call_value(
+        call_value_analytic = analytic_formula.black_scholes_call_value(
             underlying, payoff_strike, rate, maturity, vol)
         assert call_value_integral == approx(call_value_analytic)
 
@@ -1471,7 +1471,7 @@ class TestModelPricerQuantoCMS(object):
             return max(payoff_strike - strike, 0.0) * pdf(strike)
         put_value_integral = integrate.quad(
             put_integrand, 0.0, payoff_strike)[0]
-        put_value_analytic = analytic_formula.calc_black_scholes_put_value(
+        put_value_analytic = analytic_formula.black_scholes_put_value(
             underlying, payoff_strike, rate, maturity, vol)
         assert put_value_integral == approx(put_value_analytic)
 
@@ -1493,7 +1493,7 @@ class TestModelPricerQuantoCMS(object):
                 return max(strike - payoff_strike, 0.0) * pdf(strike)
             value_integral = integrate.quad(
                 integrand, payoff_strike, np.inf)[0]
-            value_analytic = analytic_formula.calc_black_scholes_call_value(
+            value_analytic = analytic_formula.black_scholes_call_value(
                 underlying, payoff_strike, rate, maturity, vol)
             assert value_integral == approx(value_analytic)
         case_call()
@@ -1509,7 +1509,7 @@ class TestModelPricerQuantoCMS(object):
                 return max(payoff_strike - strike, 0.0) * pdf(strike)
             value_integral = integrate.quad(
                 integrand, 0.0, payoff_strike)[0]
-            value_analytic = analytic_formula.calc_black_scholes_put_value(
+            value_analytic = analytic_formula.black_scholes_put_value(
                 underlying, payoff_strike, rate, maturity, vol)
             assert value_integral == approx(value_analytic)
         case_put()
@@ -1532,7 +1532,7 @@ class TestModelPricerQuantoCMS(object):
                 return max(strike - payoff_strike, 0.0) * pdf(strike)
             value_integral = integrate.quad(
                 integrand, payoff_strike, np.inf)[0]
-            value_analytic = analytic_formula.calc_black_scholes_call_value(
+            value_analytic = analytic_formula.black_scholes_call_value(
                 underlying, payoff_strike, rate, maturity, vol)
             assert value_integral == approx(value_analytic)
         case_call()
@@ -1548,7 +1548,7 @@ class TestModelPricerQuantoCMS(object):
                 return max(payoff_strike - strike, 0.0) * pdf(strike)
             value_integral = integrate.quad(
                 integrand, 0.0, payoff_strike)[0]
-            value_analytic = analytic_formula.calc_black_scholes_put_value(
+            value_analytic = analytic_formula.black_scholes_put_value(
                 underlying, payoff_strike, rate, maturity, vol)
             assert value_integral == approx(value_analytic)
         case_put()


### PR DESCRIPTION
This issue allow the pricer to calculate by following condition of parameters:

* underlying is 0
	* return discount strike
* strike is 0 and underlying is positive 
	* return initial swap rate
* strike is 0 and underlying is negative
	* return 0