### PR TITLE
Add approximation fomurla of implied volatility

### DIFF
--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -475,6 +475,72 @@ def black_scholes_call_value_third_by_strike(
     return -discount * (term1 + term2)
 
 
+def implied_vol_brenner_subrahmanyam(
+        underlying, strike, rate, maturity, option_value):
+    """implied_vol_brenner_subrahmanyam
+    calculates implied volatility by Brenner-Subrahmanym approximation formula.
+
+    .. math::
+        \sigma
+            \\approx
+                \sqrt{\\frac{2 \pi}{T}}
+                    \\frac{C}{K}
+
+    where
+    :math:`K` is `strike`,
+    :math:`T` is `maturity`,
+    :math:`C` is `option_value`.
+    If :math:`T<=0` or :math:`K \\neq 0` then, this function return 0.
+
+    :param float underlying:
+    :param float strike: this funciton returns 0 if strike is 0.
+    :param float rate:
+    :param float maturity:
+    :param float option_value:
+
+    :return: approximated implied vol at the money.
+    :rtype: float.
+    """
+    if np.isclose(strike, 0.0):
+        return 0.0
+    if maturity <= 0.0:
+        return 0.0
+    return math.sqrt(2.0 * math.pi / maturity) * option_value / strike
+
+
+def implied_vol_quadratic_approx(
+        underlying, strike, rate, maturity, option_value):
+    """implied_vol_quadratic_approx
+    calculates implied volatility by Corrado-Miller approximation formula.
+    See Corrado, C. J., & Miller, T. W. (1996).
+    A note on a simple, accurate formula
+    to compute implied standard deviations.
+    Journal of Banking & Finance, 20(1996), 595–603.
+    https://doi.org/10.1016/0378-4266(95)00014-3
+
+    :param float underlying:
+    :param float strike:
+    :param float rate:
+    :param float maturity:
+    :param float option_value:
+
+    :return: approximated implied volatility.
+        If `maturity` is not positive, this function returns 0.
+    :rtype: float.
+    """
+    if maturity <= 0.0:
+        return 0.0
+    discount_strike = math.exp(-rate * maturity) * strike
+    moneyness_delta = underlying - discount_strike
+    diff = option_value - moneyness_delta / 2.0
+    moneyness_delta2 = moneyness_delta ** 2
+    # take lower bound
+    sqrt_inner = max(diff ** 2 - moneyness_delta2 / math.pi, 0.0)
+    factor1 = diff + math.sqrt(sqrt_inner)
+    factor2 = (math.sqrt(2.0 * math.pi / maturity) / (underlying + discount_strike))
+    return factor1 * factor2
+
+
 # ----------------------------------------------------------------------------
 # Black payers/receivers swaption
 # ----------------------------------------------------------------------------

--- a/mafipy/tests/test_replication.py
+++ b/mafipy/tests/test_replication.py
@@ -241,16 +241,16 @@ class TestModelAnalyticReplication:
         assert expect == approx(actual)
 
     def test_replication_bull_spread(self):
-        data = sorted(util.get_real(3))
+        data = util.get_real(1)
         min_put_range = 1e-10
-        init_swap_rate = data[1]
+        init_swap_rate = data[0]
         max_call_range = 10.0
 
         data = util.get_real(2)
         option_maturity = data[0]
         swap_rate_vol = data[1]
 
-        data = sorted(util.get_real(2))
+        data = sorted(util.get_real(2, min_put_range, max_call_range))
         lower_strike = data[0]
         upper_strike = data[1]
 


### PR DESCRIPTION
C.J.Corrado introduces simple approximation formula for implied volatility in Corrado, C. J., & Miller, T. W. (1996). A note on a simple, accurate formula to compute implied standard deviations. Journal of Banking & Finance, 20(1996), 595–603. https://doi.org/10.1016/0378-4266(95)00014-3
Approximation formula can be used as initial guess of solver.