### PR TITLE
Add calculator of black scholes implied volatility

### DIFF
--- a/mafipy/calibrator.py
+++ b/mafipy/calibrator.py
@@ -1,0 +1,86 @@
+#!/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import division
+from mafipy import analytic_formula
+import scipy.optimize
+import numpy as np
+
+
+def black_scholes_implied_vol(underlying,
+                              strike,
+                              rate,
+                              maturity,
+                              option_value,
+                              vol_min=1e-4,
+                              vol_max=6.0,
+                              max_iter=2000):
+    """black_scholes_implied_vol
+    calculates implied volatility of black schoels model by brent method.
+
+    :param float underlying:
+    :param float strike:
+    :param float rate:
+    :param float maturity:
+    :param float option_value: value of option.
+    :param float vol_min: lower bound of volatility. default value is 1e-4.
+    :param float vol_max: upper bound of volatility. default value is 6.0.
+    :param int max_iter: maximum number of iterations. default value is 2000.
+
+    :return: implied volatility.
+    :rtype: float.
+    """
+
+    def objective_func(vol):
+        return (analytic_formula.black_scholes_call_formula(
+            underlying, strike, rate, maturity, vol) - option_value)
+
+    result = scipy.optimize.brentq(
+        objective_func,
+        vol_min,
+        vol_max,
+        xtol=4 * np.finfo(float).eps,
+        rtol=4 * np.finfo(float).eps,
+        maxiter=max_iter)
+
+    return result
+
+
+def black_swaption_implied_vol(init_swap_rate,
+                               option_strike,
+                               swap_annuity,
+                               option_maturity,
+                               option_value,
+                               vol_min=1e-4,
+                               vol_max=6.0,
+                               max_iter=2000):
+    """black_swaption_implied_vol
+    calculates implied volatility of payer's swaption by brent method.
+
+    :param float init_swap_rate:
+    :param float option_strike:
+    :param float swap_annuity:
+    :param float option_maturity:
+    :param float option_value: value of option.
+    :param float vol_min: lower bound of volatility. default value is 1e-4.
+    :param float vol_max: upper bound of volatility. default value is 6.0.
+    :param int max_iter: maximum number of iterations. default value is 2000.
+
+    :return: implied volatility.
+    :rtype: float.
+    """
+
+    def objective_func(vol):
+        return (analytic_formula.black_payers_swaption_value(
+            init_swap_rate, option_strike, swap_annuity, option_maturity, vol)
+            - option_value)
+
+    result = scipy.optimize.brentq(
+        objective_func,
+        vol_min,
+        vol_max,
+        xtol=4 * np.finfo(float).eps,
+        rtol=4 * np.finfo(float).eps,
+        maxiter=max_iter)
+
+    return result

--- a/mafipy/pricer_quanto_cms.py
+++ b/mafipy/pricer_quanto_cms.py
@@ -774,6 +774,11 @@ class _SimpleQuantoCmsLinearCallHelper(SimpleQuantoCmsHelper):
         self.max_put_range = max_put_range
         self.min_call_range = min_call_range
         self.max_call_range = max_call_range
+        # check range condition
+        # min_put_range <= max_put_range = min_call_range <= max_call_range
+        assert(min_put_range <= max_put_range)
+        assert(np.isclose(max_put_range, min_call_range))
+        assert(min_call_range <= max_call_range)
 
     def _make_numerator_integrands(self):
         """_make_numerator_integrands
@@ -873,7 +878,6 @@ class _SimpleQuantoCmsLinearCallHelper(SimpleQuantoCmsHelper):
         def func1(init_swap_rate):
             # g * a * chi
             return (self.payoff_func(init_swap_rate)
-                    * self.payoff_gearing
                     * self.annuity_mapping_func(init_swap_rate)
                     * self.forward_fx_diffusion(init_swap_rate))
 

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -1,0 +1,105 @@
+#!/bin/python
+
+from __future__ import division
+from pytest import approx
+import pytest
+import mafipy.calibrator as target
+import mafipy.analytic_formula as analytic_formula
+import mafipy.tests.util as util
+
+
+class TestModelCalibrator:
+
+    # before all tests starts
+    @classmethod
+    def setup_class(cls):
+        pass
+
+    # after all tests finish
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    # before each test start
+    def setup(self):
+        pass
+
+    # after each test finish
+    def teardown(self):
+        pass
+
+    @pytest.mark.parametrize("underlying, strike, rate, maturity, vol", [
+        # at the money
+        (2.1, 2.1, util.get(), util.get(), util.get()),
+        # out of the money
+        (1.1, 2.2, util.get(), util.get(), util.get()),
+        # in the money
+        (2.1, 1.9, util.get(), util.get(), util.get()),
+    ])
+    def test_black_scholes_implied_vol(
+            self, underlying, strike, rate, maturity, vol):
+        option_value = analytic_formula.black_scholes_call_formula(
+            underlying, strike, rate, maturity, vol)
+        implied_vol = target.black_scholes_implied_vol(
+            underlying, strike, rate, maturity, option_value)
+        assert implied_vol == approx(vol)
+
+    @pytest.mark.parametrize(
+        "init_swap_rate, option_strike, swap_annuity, option_maturity, vol", [
+            # at the money
+            (0.21, 0.21, util.get(), 1.0 / 12.0, util.get()),
+            (0.21, 0.21, util.get(), 3.0 / 12.0, util.get()),
+            (0.21, 0.21, util.get(), 6.0 / 12.0, util.get()),
+            (0.21, 0.21, util.get(), 1.0, util.get()),
+            (0.21, 0.21, util.get(), 2.0, util.get()),
+            (0.21, 0.21, util.get(), 3.0, util.get()),
+            (0.21, 0.21, util.get(), 4.0, util.get()),
+            (0.21, 0.21, util.get(), 5.0, util.get()),
+            (0.21, 0.21, util.get(), 6.0, util.get()),
+            (0.21, 0.21, util.get(), 7.0, util.get()),
+            (0.21, 0.21, util.get(), 8.0, util.get()),
+            (0.21, 0.21, util.get(), 9.0, util.get()),
+            (0.21, 0.21, util.get(), 10.0, util.get()),
+            # out of the money
+            (0.18, 0.22, util.get(), 1.0 / 12.0, util.get()),
+            (0.08, 0.22, util.get(), 3.0 / 12.0, util.get()),
+            (0.08, 0.22, util.get(), 6.0 / 12.0, util.get()),
+            (0.08, 0.22, util.get(), 1.0, util.get()),
+            (0.08, 0.22, util.get(), 2.0, util.get()),
+            (0.08, 0.22, util.get(), 3.0, util.get()),
+            (0.08, 0.22, util.get(), 4.0, util.get()),
+            (0.08, 0.22, util.get(), 5.0, util.get()),
+            (0.08, 0.22, util.get(), 6.0, util.get()),
+            (0.08, 0.22, util.get(), 7.0, util.get()),
+            (0.08, 0.22, util.get(), 8.0, util.get()),
+            (0.08, 0.22, util.get(), 9.0, util.get()),
+            (0.08, 0.22, util.get(), 10.0, util.get()),
+            # in the money
+            (0.21, 0.18, util.get(), 1.0 / 12.0, util.get()),
+            (0.21, 0.08, util.get(), 3.0 / 12.0, util.get()),
+            (0.21, 0.18, util.get(), 6.0 / 12.0, util.get()),
+            (0.21, 0.08, util.get(), 1.0, util.get()),
+            (0.21, 0.08, util.get(), 2.0, util.get()),
+            (0.21, 0.08, util.get(), 3.0, util.get()),
+            (0.21, 0.08, util.get(), 4.0, util.get()),
+            (0.21, 0.08, util.get(), 5.0, util.get()),
+            (0.21, 0.08, util.get(), 6.0, util.get()),
+            (0.21, 0.08, util.get(), 7.0, util.get()),
+            (0.21, 0.08, util.get(), 8.0, util.get()),
+            (0.21, 0.08, util.get(), 9.0, util.get()),
+            (0.21, 0.08, util.get(), 10., util.get()),
+        ])
+    def test_black_swaption_implied_vol(self,
+                                        init_swap_rate,
+                                        option_strike,
+                                        swap_annuity,
+                                        option_maturity,
+                                        vol):
+        option_value = analytic_formula.black_payers_swaption_value(
+            init_swap_rate, option_strike, swap_annuity, option_maturity, vol)
+        implied_vol = target.black_swaption_implied_vol(init_swap_rate,
+                                                        option_strike,
+                                                        swap_annuity,
+                                                        option_maturity,
+                                                        option_value)
+        assert implied_vol == approx(vol)


### PR DESCRIPTION
This issue introduces a inverse function of black scholes call opiton formula with respect to volatility.
Corrado and Miller formula is used for initial guess of implied volatility.

Corrado, C. J., & Miller, T. W. (1996). A note on a simple, accurate formula to compute implied standard deviations. Journal of Banking & Finance, 20(1996), 595–603. https://doi.org/10.1016/0378-4266(95)00014-3