### PR TITLE
Add a calibrator of SABR model

### DIFF
--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -1154,13 +1154,15 @@ def sabr_implied_vol_hagan(
     :rtype: float.
     """
     if alpha <= 0.0:
-        raise ValueError("alpha must be greater than 0.")
+        raise ValueError("alpha({0}) must be greater than 0.".format(alpha))
     if rho > 1.0 or rho < -1.0:
-        raise ValueError("rho must be between -1 and 1.")
+        raise ValueError("rho({0}) must be between -1 and 1.".format(rho))
     if nu <= 0.0:
-        raise ValueError("nu must be greater than 0.")
+        raise ValueError("nu must be greater than 0.".format(nu))
     if underlying <= 0.0:
-        raise ValueError("Approximation not defined for non-positive underlying.")
+        raise ValueError(
+            "Approximation not defined for non-positive underlying({0})."
+            .format(underlying))
 
     log_val = math.log(underlying / strike)
     log_val2 = log_val ** 2

--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -1072,15 +1072,9 @@ def calc_local_vol_model_implied_vol(
     return local_vol_val * term
 
 
-def calc_sabr_implied_vol(
-        underlying,
-        strike,
-        maturity,
-        alpha,
-        beta,
-        rho,
-        nu):
-    """calc_sabr_model_implied_vol
+def sabr_implied_vol_hagan(
+        underlying, strike, maturity, alpha, beta, rho, nu):
+    """sabr_implied_vol_hagan
     calculate implied volatility under SABR model.
 
     .. math::
@@ -1198,14 +1192,9 @@ def calc_sabr_implied_vol(
     return factor1 * factor2 * factor3
 
 
-def calc_sabr_atm_implied_vol(
-        underlying,
-        maturity,
-        alpha,
-        beta,
-        rho,
-        nu):
-    """calc_sabr_atm_implied_vol
+def sabr_atm_implied_vol_hagan(
+        underlying, maturity, alpha, beta, rho, nu):
+    """sabr_atm_implied_vol_hagan
     calculate implied volatility under SABR model at the money.
 
     .. math::

--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -1155,7 +1155,8 @@ def sabr_implied_vol_hagan(
     """
     if alpha <= 0.0:
         raise ValueError("alpha({0}) must be greater than 0.".format(alpha))
-    if rho > 1.0 or rho < -1.0:
+    if ((rho > 1.0 and not np.isclose(rho, 1.0))
+            or (rho < -1.0 and not np.isclose(rho, -1.0))):
         raise ValueError("rho({0}) must be between -1 and 1.".format(rho))
     if nu <= 0.0:
         raise ValueError("nu must be greater than 0.".format(nu))

--- a/mafipy/calibrator.py
+++ b/mafipy/calibrator.py
@@ -84,3 +84,165 @@ def black_swaption_implied_vol(init_swap_rate,
         maxiter=max_iter)
 
     return result
+
+
+def _is_real_and_positive(val):
+    """_is_real_and_positive
+
+    :param complex val:
+
+    :return: True if `val` is real and positive.
+    :rtype: bool.
+    """
+    if np.isreal(val) and val > 0.0:
+        return True
+    return False
+
+
+def _find_alpha(underlying, option_maturity, vol_atm, beta, rho, nu):
+    """_find_alpha
+    find value of alpha solving the following polynominal equation
+    with respect to alpha.
+
+    .. math::
+        \\frac{
+            (1 - \\beta)^{2} \\tau
+        }{
+            24F^{2-2\\beta}
+        }
+        \\alpha^{3}
+        +
+            \\frac{
+                \\rho\\beta\\nu\\tau
+            }{
+                4F^{1-\\beta}
+            }
+            \\alpha^{2}
+        +
+            \left(
+                1
+                +
+                \\frac{
+                    2 - 3\\rho^{2}
+                }{
+                    24
+                }
+                \\nu^{2} \\tau
+            \\right)
+            \\alpha
+        - \sigma_{\mathrm{atm}} F^{1-\\beta}
+        = 0
+
+    :param float underlying:
+    :param float option_maturity:
+    :param float vol_atm:
+    :param float beta:
+    :param float rho:
+    :param float nu:
+
+    :return: mininum real positive root of the equiation.
+    :rtype: float.
+
+    :raise ValueError:
+        if there is no positive real roots.
+    """
+    one_minus_beta = 1.0 - beta
+    one_minus_beta2 = one_minus_beta ** 2
+
+    numerator1 = one_minus_beta2 * option_maturity
+    denominator1 = 24.0 * (underlying ** (2.0 * one_minus_beta))
+    coeff1 = numerator1 / denominator1
+
+    numerator2 = rho * beta * nu * option_maturity
+    denominator2 = 4.0 * (underlying ** one_minus_beta)
+    coeff2 = numerator2 / denominator2
+
+    numerator3 = (2.0 - 3.0 * rho * rho) * nu * nu * option_maturity
+    coeff3 = (1.0 + numerator3 / 24.0)
+
+    constant_term = -vol_atm * (underlying ** one_minus_beta)
+
+    coeffs = [coeff1, coeff2, coeff3, constant_term]
+
+    roots = np.roots(coeffs)
+    # find smallest real roots
+    positive_real_roots = [
+        root.real for root in roots if _is_real_and_positive(root)]
+    if len(positive_real_roots) == 0:
+        raise ValueError("""
+Find no real positive roots for alpha:
+    underlying: {0},
+    option_maturity: {1},
+    vol_atm: {2},
+    alpha: {3},
+    beta: {4},
+    rho: {5},
+    nu: {6}""".format(underlying, option_maturity, vol_atm,
+                      roots, beta, rho, nu))
+    return min(positive_real_roots)
+
+
+def sabr_caibration_west(market_vols,
+                         market_strikes,
+                         option_maturity,
+                         beta,
+                         init_rho=0.1,
+                         init_nu=0.1):
+    """sabr_caibration_west
+    calibrates SABR parameters to market volatilities by algorithm
+    in West, G. (2005).
+    Calibration of the SABR Model in Illiquid Markets.
+    Applied Mathematical Finance, 12(4), 371–385.
+    https://doi.org/10.1080/13504860500148672
+
+    :param array market_vols: market volatilities.
+        Middle of elements in the array must be atm volatility.
+    :param array market_strikes: market strikes corresponded to `market_vol`.
+        Middle of elements in the array must be atm strike.
+    :param float option_maturity:
+    :param float beta: pre-determined beta.
+    :param float init_rho: initial guess of rho.
+        Default value is meaningless value, 0.1.
+    :param float init_nu: initial guess of nu.
+        Default value is meaningless value, 0.1.
+
+    :return: alpha, beta, rho, nu.
+    :rtype: four float value.
+
+    :raise AssertionError: if length of `market_vols` is not odd.
+    :raise AssertionError:
+        if length of `market_vols` and `market_strikes` are not same.
+    """
+    assert(len(market_vols) % 2 == 1,
+           "lenght of makret_vols must be odd")
+    assert(len(market_strikes) == len(market_vols),
+           "market_vols and market_strikes must be same lenght")
+
+    # atm strike is underlying
+    underlying = market_strikes[int(len(market_strikes) / 2)]
+    vol_atm = market_vols[int(len(market_vols) / 2)]
+
+    def find_alpha(rho, nu):
+        return _find_alpha(underlying, option_maturity, vol_atm, beta, rho, nu)
+
+    # 2-dim func
+    def objective_func(rho_nu):
+        alpha = find_alpha(rho_nu[0], rho_nu[1])
+        sabr_vols = [analytic_formula.sabr_implied_vol_hagan(
+            underlying,
+            strike,
+            option_maturity,
+            alpha,
+            beta,
+            rho_nu[0],
+            rho_nu[1]) for strike in market_strikes]
+        return np.linalg.norm(np.subtract(market_vols, sabr_vols)) ** 2
+
+    result = scipy.optimize.minimize(
+        objective_func,
+        [init_rho, init_nu],
+        method="L-BFGS-B",
+        bounds=((-1.0, 1.0), (0.0, None)))
+    rho, nu = result.x
+    alpha = find_alpha(rho, nu)
+    return alpha, beta, rho, nu

--- a/mafipy/tests/test_analytic_formula.py
+++ b/mafipy/tests/test_analytic_formula.py
@@ -916,7 +916,7 @@ class TestAnalytic(object):
         "underlying, strike, maturity, alpha, beta, rho, nu", [
             (0.0357, 0.03, 2, 0.036, 0.5, -0.25, 0.35)
         ])
-    def test_calc_sabr_implied_vol(
+    def test_sabr_implied_vol_hagan(
             self, underlying, strike, maturity, alpha, beta, rho, nu):
         one_minus_beta = 1.0 - beta
         one_minus_beta2 = one_minus_beta ** 2
@@ -954,7 +954,7 @@ class TestAnalytic(object):
         expect = factor1 * factor2 * factor3
 
         # actual
-        actual = target.calc_sabr_implied_vol(
+        actual = target.sabr_implied_vol_hagan(
             underlying, strike, maturity, alpha, beta, rho, nu)
         assert expect == actual
 
@@ -963,7 +963,7 @@ class TestAnalytic(object):
         "underlying, maturity, alpha, beta, rho, nu", [
             (0.0357, 2, 0.036, 0.5, -0.25, 0.35)
         ])
-    def test_calc_sabr_atm_implied_vol(
+    def test_sabr_atm_implied_vol_hagan(
             self, underlying, maturity, alpha, beta, rho, nu):
         one_minus_beta = 1.0 - beta
         one_minus_beta2 = one_minus_beta ** 2
@@ -984,7 +984,7 @@ class TestAnalytic(object):
         # expect
         expect = factor1 * factor2
         # actual
-        actual = target.calc_sabr_atm_implied_vol(
+        actual = target.sabr_atm_implied_vol_hagan(
             underlying, maturity, alpha, beta, rho, nu)
         assert expect == actual
 

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -103,3 +103,45 @@ class TestModelCalibrator:
                                                         option_maturity,
                                                         option_value)
         assert implied_vol == approx(vol)
+
+    def test_sabr_calibration_west(self):
+        market_vols = [45.6, 41.6, 37.9, 36.6, 37.8, 39.2, 40.0]
+        market_vols = [vol / 100.0 for vol in market_vols]
+        market_strikes = [2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]
+        market_strikes = [strike / 100.0 for strike in market_strikes]
+        option_maturity = 3.0
+
+        # beta 0
+        expect_beta = 0.0
+        alpha, beta, rho, nu = target.sabr_caibration_west(market_vols,
+                                                           market_strikes,
+                                                           option_maturity,
+                                                           expect_beta)
+        assert 0.01120935448488606 == approx(alpha)
+        assert expect_beta == approx(beta)
+        assert 0.42563951834424474 == approx(rho)
+        assert 0.84492709640795993 == approx(nu)
+
+        # beta 0.5
+        expect_beta = 0.5
+        alpha, beta, rho, nu = target.sabr_caibration_west(market_vols,
+                                                           market_strikes,
+                                                           option_maturity,
+                                                           expect_beta)
+        assert 0.05847588694407545 == approx(alpha)
+        assert expect_beta == approx(beta)
+        assert 0.20565391641295228 == approx(rho)
+        assert 0.79689209024466956 == approx(nu)
+
+        # beta 1.0
+        expect_beta = 1.0
+        alpha, beta, rho, nu = target.sabr_caibration_west(market_vols,
+                                                           market_strikes,
+                                                           option_maturity,
+                                                           expect_beta,
+                                                           init_rho=0.3,
+                                                           init_nu=0.8)
+        assert 0.31548238677601786 == approx(alpha)
+        assert expect_beta == approx(beta)
+        assert -0.030890193169276017 == approx(rho)
+        assert 0.81566639230647286 == approx(nu)


### PR DESCRIPTION
This issue adds the calibrator of SABR model.
The calibration is based on West, G. (2005). Calibration of the SABR Model in Illiquid Markets. Applied Mathematical Finance, 12(4), 371–385. https://doi.org/10.1080/13504860500148672