### PR TITLE
Add a simple calibrator of SABR model

### DIFF
--- a/mafipy/analytic_formula.py
+++ b/mafipy/analytic_formula.py
@@ -1227,8 +1227,14 @@ def sabr_implied_vol_hagan(
     # factor2
     z = (nu * common_factor1 * log_val / alpha)
     numerator2 = math.sqrt(1.0 - 2 * rho * z + z * z) + z - rho
-    x = math.log(numerator2 / (1.0 - rho)) if abs(rho - 1.0) > 1E-10 else 1.0
-    factor2 = 1.0 if (abs(x - z) < 1E-10) else z / x
+    if numerator2 <= 0.0:
+        factor2 = 0.0
+    elif np.isclose(abs(1.0 - rho), 0.0):
+        x = 1.0
+        factor2 = 1.0 if (abs(x - z) < 1E-10) else z / x
+    else:
+        x = math.log(numerator2 / (1.0 - rho))
+        factor2 = 1.0 if (abs(x - z) < 1E-10) else z / x
     # factor3
     numerator31 = one_minus_beta2 * (alpha ** 2)
     denominator31 = 24.0 * ((underlying * strike) ** one_minus_beta)

--- a/mafipy/calibrator.py
+++ b/mafipy/calibrator.py
@@ -122,7 +122,8 @@ def sabr_caibration_simple(market_vols,
                            init_alpha=None,
                            init_rho=0.1,
                            init_nu=0.1,
-                           nu_lower_bound=1e-8):
+                           nu_lower_bound=1e-8,
+                           tol=1e-8):
     """sabr_caibration_simple
     calibrates SABR parametes, alpha, rho and nu to market volatilities
     by simultaneously minimizing error of market volatilities.
@@ -144,6 +145,7 @@ def sabr_caibration_simple(market_vols,
         Default value is meaningless value, 0.1.
         nu must be positive.
     :param float nu_lower_bound:
+    :param float tol: tolerance of minimization.
 
     :return: alpha, beta, rho, nu.
     :rtype: four float value.
@@ -189,7 +191,8 @@ def sabr_caibration_simple(market_vols,
         objective_func,
         [init_alpha, init_rho, init_nu],
         method="L-BFGS-B",
-        bounds=((0.0, None), (-1.0, 1.0), (nu_lower_bound, None)))
+        bounds=((0.0, None), (-1.0, 1.0), (nu_lower_bound, None)),
+        tol=tol)
     alpha, rho, nu = result.x
     return alpha, beta, rho, nu
 

--- a/mafipy/calibrator.py
+++ b/mafipy/calibrator.py
@@ -123,7 +123,7 @@ def sabr_caibration_simple(market_vols,
                            init_rho=0.1,
                            init_nu=0.1,
                            nu_lower_bound=1e-8,
-                           tol=1e-8):
+                           tol=1e-10):
     """sabr_caibration_simple
     calibrates SABR parametes, alpha, rho and nu to market volatilities
     by simultaneously minimizing error of market volatilities.

--- a/mafipy/calibrator.py
+++ b/mafipy/calibrator.py
@@ -154,10 +154,10 @@ def sabr_caibration_simple(market_vols,
     :raise AssertionError:
         if length of `market_vols` and `market_strikes` are not same.
     """
-    assert(len(market_vols) % 2 == 1,
-           "lenght of makret_vols must be odd")
-    assert(len(market_strikes) == len(market_vols),
-           "market_vols and market_strikes must be same lenght")
+    assert len(market_vols) % 2 == 1, \
+        "lenght of makret_vols must be odd"
+    assert len(market_strikes) == len(market_vols), \
+        "market_vols and market_strikes must be same lenght"
 
     # atm strike is underlying
     underlying = market_strikes[int(len(market_strikes) / 2)]
@@ -324,10 +324,10 @@ def sabr_caibration_west(market_vols,
     :raise AssertionError:
         if length of `market_vols` and `market_strikes` are not same.
     """
-    assert(len(market_vols) % 2 == 1,
-           "lenght of makret_vols must be odd")
-    assert(len(market_strikes) == len(market_vols),
-           "market_vols and market_strikes must be same lenght")
+    assert len(market_vols) % 2 == 1, \
+        "lenght of makret_vols must be odd"
+    assert len(market_strikes) == len(market_vols), \
+        "market_vols and market_strikes must be same lenght"
 
     # atm strike is underlying
     underlying = market_strikes[int(len(market_strikes) / 2)]

--- a/mafipy/calibrator.py
+++ b/mafipy/calibrator.py
@@ -99,13 +99,15 @@ def _guess_alpha_from_vol_atm(underlying, vol_atm, beta):
         \ln\sigma(F, F)
             \\approx \ln \\alpha - (1 - \\beta) \ln F
 
-    :param float underlying:
-    :param float vol_atm: volatility at the money.
+    :param float underlying: must be positive.
+    :param float vol_atm: volatility at the money. This must be positive.
     :param float beta:
 
     :return: alpha.
     :rtype: float.
     """
+    assert(underlying > 0.0)
+    assert(vol_atm > 0.0)
     ln_underlying = math.log(underlying)
     ln_vol_atm = math.log(vol_atm)
     one_minus_beta = 1.0 - beta
@@ -131,12 +133,16 @@ def sabr_caibration_simple(market_vols,
         Middle of elements in the array must be atm strike.
     :param float option_maturity:
     :param float beta: pre-determined beta.
+        beta must be within [0, 1].
     :param float init_alpha: initial guess of alpha.
         Default value is meaningless value, 0.1.
-    :param float init_rho: initial guess of beta.
+        alpha must be positive.
+    :param float init_rho: initial guess of rho.
         Default value is meaningless value, 0.1.
+        rho must be within [-1, 1].
     :param float init_nu: initial guess of nu.
         Default value is meaningless value, 0.1.
+        nu must be positive.
     :param float nu_lower_bound:
 
     :return: alpha, beta, rho, nu.
@@ -157,6 +163,14 @@ def sabr_caibration_simple(market_vols,
 
     if init_alpha is None:
         init_alpha = _guess_alpha_from_vol_atm(underlying, vol_atm, beta)
+
+    # parameter check
+    assert(underlying > 0.0)
+    assert(vol_atm > 0.0)
+    assert(0.0 <= beta <= 1.0)
+    assert(init_alpha > 0.0)
+    assert(-1.0 <= init_rho <= 1.0)
+    assert(init_nu > 0.0)
 
     # 3-dim func
     # (alpha, rho, nu)

--- a/mafipy/calibrator.py
+++ b/mafipy/calibrator.py
@@ -320,6 +320,7 @@ def sabr_caibration_west(market_vols,
         return _find_alpha(underlying, option_maturity, vol_atm, beta, rho, nu)
 
     # 2-dim func
+    # (rho, nu)
     def objective_func(rho_nu):
         alpha = find_alpha(rho_nu[0], rho_nu[1])
         sabr_vols = [analytic_formula.sabr_implied_vol_hagan(

--- a/mafipy/calibrator.py
+++ b/mafipy/calibrator.py
@@ -5,6 +5,7 @@ from __future__ import division
 from mafipy import analytic_formula
 import scipy.optimize
 import numpy as np
+import math
 
 
 def black_scholes_implied_vol(underlying,
@@ -84,6 +85,99 @@ def black_swaption_implied_vol(init_swap_rate,
         maxiter=max_iter)
 
     return result
+
+
+# ----------------------------------------------------------------------------
+# SABR calibration
+# ----------------------------------------------------------------------------
+def _guess_alpha_from_vol_atm(underlying, vol_atm, beta):
+    """_guess_alpha_from_vol_atm_
+    guess alpha from volatility at the money
+    by using Hagan's approximated atm implied volatility.
+
+    .. math::
+        \ln\sigma(F, F)
+            \\approx \ln \\alpha - (1 - \\beta) \ln F
+
+    :param float underlying:
+    :param float vol_atm: volatility at the money.
+    :param float beta:
+
+    :return: alpha.
+    :rtype: float.
+    """
+    ln_underlying = math.log(underlying)
+    ln_vol_atm = math.log(vol_atm)
+    one_minus_beta = 1.0 - beta
+    ln_alpha = ln_vol_atm + one_minus_beta * ln_underlying
+    return math.exp(ln_alpha)
+
+
+def sabr_caibration_simple(market_vols,
+                           market_strikes,
+                           option_maturity,
+                           beta,
+                           init_alpha=None,
+                           init_rho=0.1,
+                           init_nu=0.1,
+                           nu_lower_bound=1e-8):
+    """sabr_caibration_simple
+    calibrates SABR parametes, alpha, rho and nu to market volatilities
+    by simultaneously minimizing error of market volatilities.
+
+    :param array market_vols: market volatilities.
+        Middle of elements in the array must be atm volatility.
+    :param array market_strikes: market strikes.
+        Middle of elements in the array must be atm strike.
+    :param float option_maturity:
+    :param float beta: pre-determined beta.
+    :param float init_alpha: initial guess of alpha.
+        Default value is meaningless value, 0.1.
+    :param float init_rho: initial guess of beta.
+        Default value is meaningless value, 0.1.
+    :param float init_nu: initial guess of nu.
+        Default value is meaningless value, 0.1.
+    :param float nu_lower_bound:
+
+    :return: alpha, beta, rho, nu.
+    :rtype: four float value.
+
+    :raise AssertionError: if length of `market_vols` is not odd.
+    :raise AssertionError:
+        if length of `market_vols` and `market_strikes` are not same.
+    """
+    assert(len(market_vols) % 2 == 1,
+           "lenght of makret_vols must be odd")
+    assert(len(market_strikes) == len(market_vols),
+           "market_vols and market_strikes must be same lenght")
+
+    # atm strike is underlying
+    underlying = market_strikes[int(len(market_strikes) / 2)]
+    vol_atm = market_vols[int(len(market_vols) / 2)]
+
+    if init_alpha is None:
+        init_alpha = _guess_alpha_from_vol_atm(underlying, vol_atm, beta)
+
+    # 3-dim func
+    # (alpha, rho, nu)
+    def objective_func(alpha_rho_nu):
+        sabr_vols = [analytic_formula.sabr_implied_vol_hagan(
+            underlying,
+            strike,
+            option_maturity,
+            alpha_rho_nu[0],
+            beta,
+            alpha_rho_nu[1],
+            alpha_rho_nu[2]) for strike in market_strikes]
+        return np.linalg.norm(np.subtract(market_vols, sabr_vols)) ** 2
+
+    result = scipy.optimize.minimize(
+        objective_func,
+        [init_alpha, init_rho, init_nu],
+        method="L-BFGS-B",
+        bounds=((0.0, None), (-1.0, 1.0), (nu_lower_bound, None)))
+    alpha, rho, nu = result.x
+    return alpha, beta, rho, nu
 
 
 def _is_real_and_positive(val):

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -134,11 +134,11 @@ class TestModelCalibrator:
                                                              init_rho=0.2,
                                                              init_nu=1.0,
                                                              nu_lower_bound=1e-8,
-                                                             tol=1e-12)
-        assert 0.07298722681 == approx(alpha)
+                                                             tol=1e-32)
+        assert 0.0729991374 == approx(alpha)
         assert expect_beta == approx(beta)
-        assert -0.30511803563 == approx(rho)
-        assert 2.56109959961e-05 == approx(nu)
+        assert -0.3051180437 == approx(rho)
+        assert 2.5609685118e-05 == approx(nu)
 
         # beta 1.0
         expect_beta = 1.0

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -138,7 +138,7 @@ class TestModelCalibrator:
         # for travis CI tests
         assert 0.0729991374 == approx(alpha, rel=1e-4)
         assert expect_beta == approx(beta)
-        assert -0.3051180437 == approx(rho)
+        assert -0.3051180437 == approx(rho, rel=5e-3)
         assert 2.5609685118e-05 == approx(nu)
 
         # beta 1.0

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -135,7 +135,8 @@ class TestModelCalibrator:
                                                              init_nu=1.0,
                                                              nu_lower_bound=1e-8,
                                                              tol=1e-32)
-        assert 0.0729991374 == approx(alpha)
+        # for travis CI
+        assert 0.0729991374 == approx(alpha, rel=1e-6)
         assert expect_beta == approx(beta)
         assert -0.3051180437 == approx(rho)
         assert 2.5609685118e-05 == approx(nu)

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -139,7 +139,7 @@ class TestModelCalibrator:
         assert 0.0729991374 == approx(alpha, rel=1e-4)
         assert expect_beta == approx(beta)
         assert -0.3051180437 == approx(rho, rel=5e-3)
-        assert 2.5609685118e-05 == approx(nu)
+        assert 2.5609685118e-05 == approx(nu, rel=5e-3)
 
         # beta 1.0
         expect_beta = 1.0

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -135,8 +135,8 @@ class TestModelCalibrator:
                                                              init_nu=1.0,
                                                              nu_lower_bound=1e-8,
                                                              tol=1e-32)
-        # for travis CI
-        assert 0.0729991374 == approx(alpha, rel=1e-6)
+        # for travis CI tests
+        assert 0.0729991374 == approx(alpha, rel=1e-4)
         assert expect_beta == approx(beta)
         assert -0.3051180437 == approx(rho)
         assert 2.5609685118e-05 == approx(nu)

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -119,10 +119,10 @@ class TestModelCalibrator:
                                                              expect_beta,
                                                              init_alpha=1.0,
                                                              init_nu=0.4)
-        assert 0.0135724377 == approx(alpha)
+        assert 0.0116352114 == approx(alpha)
         assert expect_beta == approx(beta)
-        assert 0.8879962646 == approx(rho)
-        assert 0.3376939549 == approx(nu)
+        assert 0.4495084250 == approx(rho)
+        assert 0.7902295128 == approx(nu)
 
         # beta 0.5
         expect_beta = 0.5
@@ -133,10 +133,10 @@ class TestModelCalibrator:
                                                              init_alpha=1.0,
                                                              init_rho=0.4,
                                                              init_nu=1.0)
-        assert 0.072998468816 == approx(alpha)
+        assert 0.0729983863 == approx(alpha)
         assert expect_beta == approx(beta)
-        assert -0.002287560228 == approx(rho)
-        assert 1e-08 == approx(nu)
+        assert -0.0022693202 == approx(rho)
+        assert 7.2087802678e-06 == approx(nu)
 
         # beta 1.0
         expect_beta = 1.0
@@ -144,10 +144,10 @@ class TestModelCalibrator:
                                                              market_strikes,
                                                              option_maturity,
                                                              expect_beta)
-        assert 0.3242845824 == approx(alpha)
+        assert 0.3242804455 == approx(alpha)
         assert expect_beta == approx(beta)
-        assert -0.041674869 == approx(rho)
-        assert 0.779416715 == approx(nu)
+        assert -0.0416661971 == approx(rho)
+        assert 0.7794312489 == approx(nu)
 
     def test_sabr_calibration_west(self):
         market_vols = [45.6, 41.6, 37.9, 36.6, 37.8, 39.2, 40.0]

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -131,12 +131,14 @@ class TestModelCalibrator:
                                                              option_maturity,
                                                              expect_beta,
                                                              init_alpha=1.0,
-                                                             init_rho=0.4,
-                                                             init_nu=1.0)
-        assert 0.0729983863 == approx(alpha)
+                                                             init_rho=0.2,
+                                                             init_nu=1.0,
+                                                             nu_lower_bound=1e-8,
+                                                             tol=1e-12)
+        assert 0.07298722681 == approx(alpha)
         assert expect_beta == approx(beta)
-        assert -0.0022693202 == approx(rho)
-        assert 7.2087802678e-06 == approx(nu)
+        assert -0.30511803563 == approx(rho)
+        assert 2.56109959961e-05 == approx(nu)
 
         # beta 1.0
         expect_beta = 1.0
@@ -162,10 +164,10 @@ class TestModelCalibrator:
                                                            market_strikes,
                                                            option_maturity,
                                                            expect_beta)
-        assert 0.01120935448488606 == approx(alpha)
+        assert 0.01120946664130403 == approx(alpha)
         assert expect_beta == approx(beta)
-        assert 0.42563951834424474 == approx(rho)
-        assert 0.84492709640795993 == approx(nu)
+        assert 0.42567236979991263 == approx(rho)
+        assert 0.84491343183536094 == approx(nu)
 
         # beta 0.5
         expect_beta = 0.5

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -119,10 +119,10 @@ class TestModelCalibrator:
                                                              expect_beta,
                                                              init_alpha=1.0,
                                                              init_nu=0.4)
-        assert 0.011635211452325815 == approx(alpha)
+        assert 0.0135724377 == approx(alpha)
         assert expect_beta == approx(beta)
-        assert 0.44950842505742067 == approx(rho)
-        assert 0.79022951280448872 == approx(nu)
+        assert 0.8879962646 == approx(rho)
+        assert 0.3376939549 == approx(nu)
 
         # beta 0.5
         expect_beta = 0.5
@@ -133,10 +133,10 @@ class TestModelCalibrator:
                                                              init_alpha=1.0,
                                                              init_rho=0.4,
                                                              init_nu=1.0)
-        assert 0.072998386300577478 == approx(alpha)
+        assert 0.072998468816 == approx(alpha)
         assert expect_beta == approx(beta)
-        assert -0.0022693202595415003 == approx(rho)
-        assert 7.2087802678177824e-06 == approx(nu)
+        assert -0.002287560228 == approx(rho)
+        assert 1e-08 == approx(nu)
 
         # beta 1.0
         expect_beta = 1.0
@@ -144,10 +144,10 @@ class TestModelCalibrator:
                                                              market_strikes,
                                                              option_maturity,
                                                              expect_beta)
-        assert 0.32428044550489138 == approx(alpha)
+        assert 0.3242845824 == approx(alpha)
         assert expect_beta == approx(beta)
-        assert -0.04166619718593862 == approx(rho)
-        assert 0.77943124899553162 == approx(nu)
+        assert -0.041674869 == approx(rho)
+        assert 0.779416715 == approx(nu)
 
     def test_sabr_calibration_west(self):
         market_vols = [45.6, 41.6, 37.9, 36.6, 37.8, 39.2, 40.0]

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -104,6 +104,51 @@ class TestModelCalibrator:
                                                         option_value)
         assert implied_vol == approx(vol)
 
+    def test_sabr_calibration_simple(self):
+        market_vols = [45.6, 41.6, 37.9, 36.6, 37.8, 39.2, 40.0]
+        market_vols = [vol / 100.0 for vol in market_vols]
+        market_strikes = [2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]
+        market_strikes = [strike / 100.0 for strike in market_strikes]
+        option_maturity = 3.0
+
+        # beta 0
+        expect_beta = 0.0
+        alpha, beta, rho, nu = target.sabr_caibration_simple(market_vols,
+                                                             market_strikes,
+                                                             option_maturity,
+                                                             expect_beta,
+                                                             init_alpha=1.0,
+                                                             init_nu=0.4)
+        assert 0.011635211452325815 == approx(alpha)
+        assert expect_beta == approx(beta)
+        assert 0.44950842505742067 == approx(rho)
+        assert 0.79022951280448872 == approx(nu)
+
+        # beta 0.5
+        expect_beta = 0.5
+        alpha, beta, rho, nu = target.sabr_caibration_simple(market_vols,
+                                                             market_strikes,
+                                                             option_maturity,
+                                                             expect_beta,
+                                                             init_alpha=1.0,
+                                                             init_rho=0.4,
+                                                             init_nu=1.0)
+        assert 0.072998386300577478 == approx(alpha)
+        assert expect_beta == approx(beta)
+        assert -0.0022693202595415003 == approx(rho)
+        assert 7.2087802678177824e-06 == approx(nu)
+
+        # beta 1.0
+        expect_beta = 1.0
+        alpha, beta, rho, nu = target.sabr_caibration_simple(market_vols,
+                                                             market_strikes,
+                                                             option_maturity,
+                                                             expect_beta)
+        assert 0.32428044550489138 == approx(alpha)
+        assert expect_beta == approx(beta)
+        assert -0.04166619718593862 == approx(rho)
+        assert 0.77943124899553162 == approx(nu)
+
     def test_sabr_calibration_west(self):
         market_vols = [45.6, 41.6, 37.9, 36.6, 37.8, 39.2, 40.0]
         market_vols = [vol / 100.0 for vol in market_vols]


### PR DESCRIPTION
This issue adds the simple calibrator of SABR model.
The algorithm of the calibration is as follows:

1. Set beta
	* beta is determined by historical market data or preference of the user.
2. Calibrate alpha, rho and nu to option values in markets