### PR TITLE
Add benchmarks to measure performance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "docs/build"]
 	path = docs/build
 	url = https://github.com/i05nagai/mafipy_docs.git
+[submodule "benchmarks/html"]
+	path = benchmarks/html
+	url = https://github.com/i05nagai/mafipy_benchmarks.git

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -1,0 +1,26 @@
+mafipy benchmarks
+==================
+mafipy benchmarks with Airspeed Velocity.
+
+Requirements
+============
+
+```shell
+pip install asv
+pip install virtualenv
+```
+
+Usage
+============
+Executing benchmarks.
+
+.. code:: shell
+
+   python run.py run
+
+Generating html and previewing html
+
+.. code:: shell
+
+   python run.py publish
+   python run.py preview

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -1,0 +1,142 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "mafipy",
+
+    // The project's homepage
+    "project_url": "",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": "../../mafipy",
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    "branches": ["master"], 
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    //"install_timeout": 600,
+
+    // the base URL to show a commit for the project.
+    // "show_commit_url": "http://github.com/owner/project/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": [""],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list or empty string indicates to just test against the default
+    // (latest) version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed via
+    // pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    "matrix": {
+         //"numpy": ["1.7"],
+         "scipy": ["0.18"],
+    //     "numpy": ["1.6", "1.7"],
+    //     "six": ["", null],        // test with and without six installed
+    //     "pip+emcee": [""],   // emcee is only available for install with pip.
+    },
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    // ],
+    //
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "numpy": "1.8"},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": "env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": "results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": "html",
+
+    // The number of characters to retain in the commit hashes.
+    "hash_length": 8,
+
+    // `asv` will cache wheels of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // number of builds to keep, per environment.
+    "wheel_cache_size": 10
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // }
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // }
+}

--- a/benchmarks/benchmarks/__init__.py
+++ b/benchmarks/benchmarks/__init__.py
@@ -1,0 +1,3 @@
+import random
+
+random.seed(1234)

--- a/benchmarks/benchmarks/bull_spread_qunato_cms.py
+++ b/benchmarks/benchmarks/bull_spread_qunato_cms.py
@@ -1,0 +1,158 @@
+#!/bin/python
+
+# for asv
+try:
+    from mafipy import pricer_quanto_cms
+    from mafipy import analytic_formula
+except ImportError as err:
+    print("Import error:{0}".format(err))
+    pass
+
+# swap rate
+INIT_SWAP_RATE = 0.018654
+SWAP_ANNUITY = 1.0
+SWAP_FIXING_DATE = (365 * 2 - 14.0) / 365.0
+VOL_SWAP_RATE = 0.39
+# forward fx
+VOL_FORWARD_FX = 0.13
+CORR_FORWARD_FX = 0.3
+# payoff
+CMS_GEARING = 1.0 / 0.018654
+CMS_LOWER_STRIKE = 1e-10
+CMS_UPPER_STRIKE = 0.018654
+# annuity mapping func
+ALPHA0 = (0.97990869 / SWAP_ANNUITY - 0.5) / SWAP_ANNUITY - 0.5
+ALPHA1 = 0.5
+
+
+def linear_annuity_bull_spread_pricer(
+        init_swap_rate,
+        swap_annuity,
+        vol_swap_rate,
+        swap_fixing_date,
+        vol_forward_fx,
+        corr_forward_fx,
+        cms_lower_strike,
+        cms_upper_strike,
+        cms_gearing,
+        alpha0,
+        alpha1):
+
+    payoff_params = {
+        "lower_strike": cms_lower_strike,
+        "upper_strike": cms_upper_strike,
+        "gearing": cms_gearing,
+    }
+    swap_rate_cdf = pricer_quanto_cms.make_cdf_black_swaption(
+        init_swap_rate=init_swap_rate,
+        swap_annuity=swap_annuity,
+        option_maturity=swap_fixing_date,
+        vol=vol_swap_rate)
+    swap_rate_pdf = pricer_quanto_cms.make_pdf_black_swaption(
+        init_swap_rate=init_swap_rate,
+        swap_annuity=swap_annuity,
+        option_maturity=swap_fixing_date,
+        vol=vol_swap_rate)
+    swap_rate_pdf_fprime = pricer_quanto_cms.make_pdf_fprime_black_swaption(
+        init_swap_rate=init_swap_rate,
+        swap_annuity=swap_annuity,
+        option_maturity=swap_fixing_date,
+        vol=vol_swap_rate)
+    annuity_mapping_params = {
+        "alpha0": alpha0,
+        "alpha1": alpha1
+    }
+    forward_fx_diffusion_params = {
+        "time": swap_fixing_date,
+        "vol": vol_forward_fx,
+        "corr": corr_forward_fx,
+        "swap_rate_cdf": swap_rate_cdf,
+        "swap_rate_pdf": swap_rate_pdf,
+        "swap_rate_pdf_fprime": swap_rate_pdf_fprime,
+        "is_inverse": True
+    }
+    payer_pricer_params = {
+        "init_swap_rate": init_swap_rate,
+        "swap_annuity": swap_annuity,
+        "option_maturity": swap_fixing_date,
+        "vol": vol_swap_rate,
+    }
+    bs_pricer = analytic_formula.BlackSwaptionPricerHelper()
+    payer_pricer = bs_pricer.make_payers_swaption_wrt_strike(
+        **payer_pricer_params)
+    receiver_pricer_params = {
+        "init_swap_rate": init_swap_rate,
+        "swap_annuity": swap_annuity,
+        "option_maturity": swap_fixing_date,
+        "vol": vol_swap_rate
+    }
+    receiver_pricer = bs_pricer.make_receivers_swaption_wrt_strike(
+        **receiver_pricer_params)
+    discount_factor = 1.0
+    price = pricer_quanto_cms.replicate(
+        init_swap_rate,
+        discount_factor,
+        payer_pricer,
+        receiver_pricer,
+        "bull_spread",
+        payoff_params,
+        forward_fx_diffusion_params,
+        "linear",
+        annuity_mapping_params,
+        min_put_range=1e-16,
+        max_call_range=0.040)
+    return price
+
+
+def gen_params(key, value):
+    params = {
+        "init_swap_rate": INIT_SWAP_RATE,
+        "swap_annuity": SWAP_ANNUITY,
+        "vol_swap_rate": VOL_SWAP_RATE,
+        "swap_fixing_date": SWAP_FIXING_DATE,
+        "vol_forward_fx": VOL_FORWARD_FX,
+        "corr_forward_fx": CORR_FORWARD_FX,
+        "cms_lower_strike": CMS_LOWER_STRIKE,
+        "cms_upper_strike": CMS_UPPER_STRIKE,
+        "cms_gearing": CMS_GEARING,
+        "alpha0": ALPHA0,
+        "alpha1": ALPHA1
+    }
+    params[key] = value
+    return params
+
+
+def time_vol_swap_rate():
+    vol_swap_rate = 0.05
+    params = gen_params("vol_swap_rate", vol_swap_rate)
+    linear_annuity_bull_spread_pricer(**params)
+    vol_swap_rate = 0.5
+    params = gen_params("vol_swap_rate", vol_swap_rate)
+    linear_annuity_bull_spread_pricer(**params)
+    vol_swap_rate = 1.0
+    params = gen_params("vol_swap_rate", vol_swap_rate)
+    linear_annuity_bull_spread_pricer(**params)
+
+
+def time_corr_forward_fx():
+    corr_forward_fx = -1.0
+    params = gen_params("corr_forward_fx", corr_forward_fx)
+    linear_annuity_bull_spread_pricer(**params)
+    corr_forward_fx = 0.0
+    params = gen_params("corr_forward_fx", corr_forward_fx)
+    linear_annuity_bull_spread_pricer(**params)
+    corr_forward_fx = 1.0
+    params = gen_params("corr_forward_fx", corr_forward_fx)
+    linear_annuity_bull_spread_pricer(**params)
+
+
+def time_vol_foward_fx():
+    vol_forward_fx = 0.05
+    params = gen_params("vol_forward_fx", vol_forward_fx)
+    linear_annuity_bull_spread_pricer(**params)
+    vol_forward_fx = 0.5
+    params = gen_params("vol_forward_fx", vol_forward_fx)
+    linear_annuity_bull_spread_pricer(**params)
+    vol_forward_fx = 1.0
+    params = gen_params("vol_forward_fx", vol_forward_fx)
+    linear_annuity_bull_spread_pricer(**params)

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="This script is ...")
+    parser.add_argument('--debug',
+                        action='store_true',
+                        default=False,
+                        help='debug mode if this flag is set (default: False)')
+    parser.add_argument("asv_command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    sys.exit(run_asv(args.asv_command))
+
+
+def run_asv(args):
+    cwd = os.path.abspath(os.path.dirname(__file__))
+    cmd = ["asv"] + list(args)
+    env = dict(os.environ)
+
+    # Run
+    try:
+        return subprocess.call(cmd, env=env, cwd=cwd)
+    except OSError as err:
+        if err.errno == 2:
+            print("Error when running '%s': %s\n" % (" ".join(cmd), str(err),))
+            print("You need to install Airspeed Velocity https://spacetelescope.github.io/asv/")
+            print("to run Scipy benchmarks")
+            return 1
+        raise
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This issue introduces regression and benchmarking test with Airspeed Velocity.
Following links are useful to setup.

* [airspeed velocity — airspeed velocity 0.3.dev1071+390145a5 documentation](http://asv.readthedocs.io/en/latest/)
* [numpy/benchmarks at master · numpy/numpy](https://github.com/numpy/numpy/tree/master/benchmarks) 
	* repository which is using asv
* [airspeed velocity of an unladen astropy](http://www.astropy.org/astropy-benchmarks/)
	* an example airspeed velocity site.