### PR TITLE
Fix deploy settings of benchmarks

### DIFF
--- a/ci/circle_ci/deployment.sh
+++ b/ci/circle_ci/deployment.sh
@@ -11,7 +11,7 @@ TARGET_BRANCH="master"
 if [ "${BENCHMARK_TEST}" = "true" ]; then
 
 	# Pull requests and commits to other branches shouldn't try to deploy, just build to verify
-	if [ "$CI_PULL_REQUEST" == "" -o "$CIRCLE_BRANCH" != "$TEST_BRANCH" ]; then
+	if [ "$CI_PULL_REQUEST" != "" -o "$CIRCLE_BRANCH" != "$TEST_BRANCH" ]; then
 		echo "Skipping deploy; just doing a build."
 		exit 0
 	fi


### PR DESCRIPTION
Deploy condition is not correct.
We skip deployment if one of the following conditions are satisfied

* pull request
* test branch is not `master`

[mafipy/deployment.sh at master · i05nagai/mafipy](https://github.com/i05nagai/mafipy/blob/master/ci/circle_ci/deployment.sh#L14)