### PR TITLE
Fix circle ci scripts

### DIFF
--- a/ci/circle_ci/test.sh
+++ b/ci/circle_ci/test.sh
@@ -4,9 +4,10 @@ set -e
 set -x
 
 if [ "${BENCHMARK_TEST}" = "true" ]; then
-	# for detached HEAD
 	pushd benchmarks/asv_files
+	# for detached HEAD
 	git checkout master
+	git pull origin master
 	popd
 
 	# run benchmarks test


### PR DESCRIPTION
Circle CI scripts does not push benchmarks to [i05nagai/mafipy_benchmarks: mafipy benchmarks](https://github.com/i05nagai/mafipy_benchmarks).
This issue is modification of #57 #58, #60, #61 and #62.