### PR TITLE
Refactor too long lines

### DIFF
--- a/mafipy/pricer_quanto_cms.py
+++ b/mafipy/pricer_quanto_cms.py
@@ -1310,7 +1310,8 @@ def _replicate_denominator(init_swap_rate,
                 * forward_fx_diffusion_fhess(swap_rate))
 
     # put integrands
-    put_integrands = [alpha_fhess_chi, alpha_fprime_chi_fprime, alpha_chi_fhess]
+    put_integrands = [
+        alpha_fhess_chi, alpha_fprime_chi_fprime, alpha_chi_fhess]
     # call integrands
     call_integrands = put_integrands
 

--- a/mafipy/tests/test_analytic_formula.py
+++ b/mafipy/tests/test_analytic_formula.py
@@ -1527,13 +1527,14 @@ class TestBlackScholesPricerHelper:
     ])
     def test_make_call_wrt_strike(
             self, underlying, rate, maturity, vol, today):
-        expect_func = lambda strike: target.black_scholes_call_value(
-            underlying=underlying,
-            strike=strike,
-            rate=rate,
-            maturity=maturity,
-            vol=vol,
-            today=today)
+        def expect_func(strike):
+            return target.black_scholes_call_value(
+                underlying=underlying,
+                strike=strike,
+                rate=rate,
+                maturity=maturity,
+                vol=vol,
+                today=today)
         actual_func = self.target_class.make_call_wrt_strike(
             underlying, rate, maturity, vol, today)
         assert type(expect_func) == type(actual_func)
@@ -1543,13 +1544,14 @@ class TestBlackScholesPricerHelper:
     ])
     def test_make_put_wrt_strike(
             self, underlying, rate, maturity, vol, today):
-        expect_func = lambda strike: target.black_scholes_put_value(
-            underlying=underlying,
-            strike=strike,
-            rate=rate,
-            maturity=maturity,
-            vol=vol,
-            today=today)
+        def expect_func(strike):
+            target.black_scholes_put_value(
+                underlying=underlying,
+                strike=strike,
+                rate=rate,
+                maturity=maturity,
+                vol=vol,
+                today=today)
         actual_func = self.target_class.make_put_wrt_strike(
             underlying, rate, maturity, vol, today)
         assert type(expect_func) == type(actual_func)

--- a/mafipy/tests/test_calibrator.py
+++ b/mafipy/tests/test_calibrator.py
@@ -126,15 +126,16 @@ class TestModelCalibrator:
 
         # beta 0.5
         expect_beta = 0.5
-        alpha, beta, rho, nu = target.sabr_caibration_simple(market_vols,
-                                                             market_strikes,
-                                                             option_maturity,
-                                                             expect_beta,
-                                                             init_alpha=1.0,
-                                                             init_rho=0.2,
-                                                             init_nu=1.0,
-                                                             nu_lower_bound=1e-8,
-                                                             tol=1e-32)
+        alpha, beta, rho, nu = target.sabr_caibration_simple(
+            market_vols,
+            market_strikes,
+            option_maturity,
+            expect_beta,
+            init_alpha=1.0,
+            init_rho=0.2,
+            init_nu=1.0,
+            nu_lower_bound=1e-8,
+            tol=1e-32)
         # for travis CI tests
         assert 0.0729991374 == approx(alpha, rel=1e-4)
         assert expect_beta == approx(beta)

--- a/mafipy/tests/test_payoff.py
+++ b/mafipy/tests/test_payoff.py
@@ -224,7 +224,8 @@ class TestPayoff(object):
                                      gearing):
         expect = (target.payoff_call(underlying, spot_price - spread, gearing)
                   - 2.0 * target.payoff_call(underlying, spot_price, gearing)
-                  + target.payoff_call(underlying, spot_price + spread, gearing))
+                  + target.payoff_call(
+                      underlying, spot_price + spread, gearing))
         if spread < 0.0:
             return 0.0
         actual = target.payoff_butterfly_spread(

--- a/mafipy/tests/test_pricer_quanto_cms.py
+++ b/mafipy/tests/test_pricer_quanto_cms.py
@@ -120,13 +120,14 @@ class TestPricerQuantoCms(object):
     # -------------------------------------------------------------------------
     # Black scholes model
     # -------------------------------------------------------------------------
-    @pytest.mark.parametrize("underlying, strike, rate, maturity, vol, expect", [
-        # maturity < 0 raise AssertionError
-        (2.0, 1.0, 1.0, -1.0, 1.0, 1.0),
-        # vol < 0 raise AssertionError
-        (2.0, 1.0, 1.0, 1.0, -1.0, 1.0),
-        (2.0, 1.0, 1.0, 1.0, 1.0, 1.0),
-    ])
+    @pytest.mark.parametrize(
+        "underlying, strike, rate, maturity, vol, expect", [
+            # maturity < 0 raise AssertionError
+            (2.0, 1.0, 1.0, -1.0, 1.0, 1.0),
+            # vol < 0 raise AssertionError
+            (2.0, 1.0, 1.0, 1.0, -1.0, 1.0),
+            (2.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+        ])
     def test_make_pdf_black_scholes(
             self, underlying, strike, rate, maturity, vol, expect):
         # raise AssertionError
@@ -994,8 +995,9 @@ class Test_SimpleQuantoCmsLinearBullSpreadHelper(object):
             "alpha0": self.alpha0,
             "alpha1": self.alpha1
         }
-        self.annuity_mapping_helper = replication.LinearAnnuityMappingFuncHelper(
-            **self.annuity_mapping_params)
+        self.annuity_mapping_helper = (
+            replication.LinearAnnuityMappingFuncHelper(
+                **self.annuity_mapping_params))
         self.annuity_mapping_func = self.annuity_mapping_helper.make_func()
         self.annuity_mapping_fprime = self.annuity_mapping_helper.make_fprime()
         self.annuity_mapping_fhess = self.annuity_mapping_helper.make_fhess()
@@ -1021,7 +1023,8 @@ class Test_SimpleQuantoCmsLinearBullSpreadHelper(object):
         }
         self.forward_fx_diffusion_helper = target._ForwardFxDiffusionHelper(
             **self.forward_fx_diffusion_params)
-        self.forward_fx_diffusion = self.forward_fx_diffusion_helper.make_func()
+        self.forward_fx_diffusion = (
+            self.forward_fx_diffusion_helper.make_func())
         self.forward_fx_diffusion_fprime = (
             self.forward_fx_diffusion_helper.make_fprime())
         self.forward_fx_diffusion_fhess = (


### PR DESCRIPTION
This issue is related to #71.

PEP8 says that limit all lines to a maximum of 79 characters.
Code climate makes a list of all lines over 79 characters.
* [Issues - i05nagai/mafipy - Code Climate](https://codeclimate.com/github/i05nagai/mafipy/issues)