### PR TITLE
Add distribution of SABR model

### DIFF
--- a/mafipy/function/black.py
+++ b/mafipy/function/black.py
@@ -306,3 +306,55 @@ def black_payers_swaption_vega(
     bs_vega = mafipy.function.black_scholes_call_vega(
         init_swap_rate, option_strike, 0.0, option_maturity, vol)
     return swap_annuity * bs_vega
+
+
+# ----------------------------------------------------------------------------
+# black payer's/reciever's swaption distribution
+# ----------------------------------------------------------------------------
+def black_swaption_cdf(
+        init_swap_rate, option_strike, swap_annuity, option_maturity, vol):
+    """black_swaption_cdf
+    calculates value of c.d.f. of black swaption.
+    :py:func:`black_payers_swaption_value_fprime_by_strike`.
+
+    :param float init_swap_rate: initial swap rate.
+    :param float option_strike: option strike.
+    :param float swap_annuity: swap annuity.
+    :param float option_maturity: maturity of swaption.
+    :param float vol: volatility. non-negative.
+
+    :return: value of c.d.f. of black swaption model.
+    :rtype: float.
+    """
+    assert(vol > 0.0)
+    return (1.0
+            + black_payers_swaption_value_fprime_by_strike(
+                init_swap_rate,
+                option_strike,
+                swap_annuity,
+                option_maturity,
+                vol) / swap_annuity)
+
+
+def black_swaption_pdf(
+        init_swap_rate, option_strike, swap_annuity, option_maturity, vol):
+    """black_swaption_pdf
+    calculates value of p.d.f. of black swaption.
+    :py:func:`black_payers_swaption_value_fhess_by_strike`.
+
+    :param float init_swap_rate: initial swap rate.
+    :param float option_strike: option strike.
+    :param float swap_annuity: swap annuity.
+    :param float option_maturity: maturity of swaption.
+    :param float vol: volatility. non-negative.
+
+    :return: value of p.d.f. of black swaption model.
+    :rtype: float.
+    """
+    assert(vol > 0.0)
+    return (black_payers_swaption_value_fhess_by_strike(
+        init_swap_rate,
+        option_strike,
+        swap_annuity,
+        option_maturity,
+        vol) / swap_annuity)

--- a/mafipy/function/black.py
+++ b/mafipy/function/black.py
@@ -330,6 +330,29 @@ def black_payers_swaption_volga(
     return swap_annuity * bs_volga
 
 
+def black_payers_swaption_vega_fprime_by_strike(
+        init_swap_rate, option_strike, swap_annuity, option_maturity, vol):
+    """black_payers_swaption_vega_fprime_by_strike
+    calculates derivative of vega with respect to strike under black model.
+    This is required for :py:func:`sabr_pdf`.
+
+    :param float init_swap_rate: initial swap rate.
+    :param float option_strike: swaption strike.
+    :param float swap_annuity: annuity of referencing swap
+    :param float option_maturity: swaption maturity.
+    :param float vol: volatilty. this must be positive.
+
+    :return: derivative of vega w.r.t. strike.
+    :rtype: float.
+
+    :raises AssertionError: if volatility is not positive.
+    """
+    assert(vol > 0.0)
+    bs_vega_fprime = mafipy.function.black_scholes_call_vega_fprime_by_strike(
+        init_swap_rate, option_strike, 0.0, option_maturity, vol)
+    return swap_annuity * bs_vega_fprime
+
+
 # ----------------------------------------------------------------------------
 # black payer's/reciever's swaption distribution
 # ----------------------------------------------------------------------------

--- a/mafipy/function/black.py
+++ b/mafipy/function/black.py
@@ -308,6 +308,28 @@ def black_payers_swaption_vega(
     return swap_annuity * bs_vega
 
 
+def black_payers_swaption_volga(
+        init_swap_rate, option_strike, swap_annuity, option_maturity, vol):
+    """black_payers_swaption_volga
+    calculates volga of payer's swaption under black model.
+
+    :param float init_swap_rate: initial swap rate.
+    :param float option_strike: swaption strike.
+    :param float swap_annuity: annuity of referencing swap
+    :param float option_maturity: swaption maturity.
+    :param float vol: volatilty. this must be positive.
+
+    :return: volga.
+    :rtype: float.
+
+    :raises AssertionError: if volatility is not positive.
+    """
+    assert(vol > 0.0)
+    bs_volga = mafipy.function.black_scholes_call_volga(
+        init_swap_rate, option_strike, 0.0, option_maturity, vol)
+    return swap_annuity * bs_volga
+
+
 # ----------------------------------------------------------------------------
 # black payer's/reciever's swaption distribution
 # ----------------------------------------------------------------------------

--- a/mafipy/function/black_scholes.py
+++ b/mafipy/function/black_scholes.py
@@ -487,13 +487,15 @@ def black_scholes_call_delta(underlying, strike, rate, maturity, vol):
     :param float underlying:
     :param float strike:
     :param float rate:
-    :param float maturity: must be non-negative.
+    :param float maturity: if maturity <= 0, this function returns 0.
     :param float vol: volatility. This must be positive.
+
     :return: value of delta.
     :rtype: float.
     """
-    assert(maturity >= 0.0)
     assert(vol >= 0.0)
+    if maturity <= 0.0:
+        return 0.0
     d1 = func_d1(underlying, strike, rate, maturity, vol)
     return scipy.stats.norm.cdf(d1)
 
@@ -557,13 +559,15 @@ def black_scholes_call_vega(underlying, strike, rate, maturity, vol):
     :param float underlying:
     :param float strike:
     :param float rate:
-    :param float maturity: must be non-negative.
+    :param float maturity: if maturity <= 0.0, this function returns 0.
     :param float vol: volatility. This must be positive.
+
     :return: value of vega.
     :rtype: float.
     """
-    assert(maturity >= 0.0)
     assert(vol >= 0.0)
+    if maturity <= 0.0:
+        return 0.0
     d1 = func_d1(underlying, strike, rate, maturity, vol)
     return math.sqrt(maturity) * underlying * scipy.stats.norm.pdf(d1)
 

--- a/mafipy/function/black_scholes.py
+++ b/mafipy/function/black_scholes.py
@@ -612,7 +612,9 @@ def black_scholes_call_volga(underlying, strike, rate, maturity, vol):
         return 0.0
     d1 = func_d1(underlying, strike, rate, maturity, vol)
     pdf_fprime = mafipy.function.norm_pdf_fprime(d1)
-    factor = (0.5 * vol * vol - rate) * maturity / (vol * vol)
+    ln_moneyness = math.log(underlying / strike)
+    numerator = -ln_moneyness + (0.5 * vol * vol - rate) * maturity
+    factor = numerator / (vol * vol)
 
     return underlying * pdf_fprime * factor
 

--- a/mafipy/function/black_scholes.py
+++ b/mafipy/function/black_scholes.py
@@ -692,3 +692,51 @@ def black_scholes_call_rho(underlying, strike, rate, maturity, vol, today):
     time = maturity - today
     d2 = func_d2(underlying, strike, rate, time, vol)
     return time * math.exp(-rate * time) * strike * norm.cdf(d2)
+
+
+# ----------------------------------------------------------------------------
+# Black scholes distributions
+# ----------------------------------------------------------------------------
+def black_scholes_cdf(underlying, strike, rate, maturity, vol):
+    """black_scholes_cdf
+    calculates value of c.d.f. of black scholes model.
+
+    :param float underlying:
+    :param float strike:
+    :param float rate:
+    :param float maturity:
+    :param float vol:
+
+    :return: value of p.d.f. of black scholes model.
+    :rtype: float.
+    """
+    assert(vol > 0.0)
+    return (1.0
+            + black_scholes_call_value_fprime_by_strike(
+                underlying,
+                strike,
+                rate,
+                maturity,
+                vol) * math.exp(rate * maturity))
+
+
+def black_scholes_pdf(underlying, strike, rate, maturity, vol):
+    """black_scholes_pdf
+    calculates value of p.d.f. of black scholes model.
+
+    :param float underlying:
+    :param float strike:
+    :param float rate:
+    :param float maturity:
+    :param float vol:
+
+    :return: value of p.d.f. of black scholes model.
+    :rtype: float.
+    """
+    assert(vol > 0.0)
+    return (black_scholes_call_value_fhess_by_strike(
+        underlying,
+        strike,
+        rate,
+        maturity,
+        vol) * math.exp(rate * maturity))

--- a/mafipy/function/sabr.py
+++ b/mafipy/function/sabr.py
@@ -1648,3 +1648,42 @@ def sabr_payers_swaption_delta(
         alpha, beta, rho, nu)
 
     return bs_delta + bs_vega * backbone
+
+
+# ----------------------------------------------------------------------------
+# SABR distribution
+# ----------------------------------------------------------------------------
+def sabr_cdf(underlying, strike, maturity, alpha, beta, rho, nu):
+    vol = sabr_implied_vol_hagan(
+        underlying, strike, maturity, alpha, beta, rho, nu)
+    bs_cdf = mafipy.function.black_swaption_cdf(
+        underlying, strike, 1.0, maturity, vol)
+    bs_vega = mafipy.function.black_payers_swaption_vega(
+        underlying, strike, 1.0, maturity, vol)
+    vol_fprime = sabr_implied_vol_hagan_fprime_by_strike(
+        underlying, strike, maturity, alpha, beta, rho, nu)
+
+    return bs_cdf + bs_vega * vol_fprime
+
+
+def sabr_pdf(underlying, strike, maturity, alpha, beta, rho, nu):
+    mf = mafipy.function
+    vol = sabr_implied_vol_hagan(
+        underlying, strike, maturity, alpha, beta, rho, nu)
+    bs_pdf = mf.black_swaption_pdf(
+        underlying, strike, 1.0, maturity, vol)
+    bs_vega = mf.black_payers_swaption_vega(
+        underlying, strike, 1.0, maturity, vol)
+    bs_volga = mf.black_payers_swaption_volga(
+        underlying, strike, 1.0, maturity, vol)
+    bs_vega_fprime = mf.black_payers_swaption_vega_fprime_by_strike(
+        underlying, strike, 1.0, maturity, vol)
+    vol_fprime = sabr_implied_vol_hagan_fprime_by_strike(
+        underlying, strike, maturity, alpha, beta, rho, nu)
+    vol_fhess = sabr_implied_vol_hagan_fhess_by_strike(
+        underlying, strike, maturity, alpha, beta, rho, nu)
+
+    return (bs_pdf
+            + 2.0 * bs_vega_fprime * vol_fprime
+            + bs_volga * vol_fprime * vol_fprime
+            + bs_vega * vol_fhess)

--- a/mafipy/function/tests/test_black.py
+++ b/mafipy/function/tests/test_black.py
@@ -1,13 +1,14 @@
 #!/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from pytest import approx
-import numpy as np
-import pytest
-
 import mafipy.function as function
 import mafipy.function.black as target
+import numpy as np
+import pytest
 
 
 class TestBlack(object):
@@ -303,3 +304,91 @@ class TestBlack(object):
             option_maturity,
             vol)
         assert expect == approx(actual)
+
+    # -------------------------------------------------------------------------
+    # black payer's/reciever's swaption distribution
+    # -------------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "init_swap_rate, option_strike, swap_annuity, option_maturity, vol",
+        [
+            # vol < 0 raise AssertionError
+            (1.1, 2.1, 1.2, 1.3, -0.1),
+            # otherwise
+            (1.1, 2.1, 1.2, 1.3, 0.1),
+        ])
+    def test_black_payers_swaption_cdf(self,
+                                       init_swap_rate,
+                                       option_strike,
+                                       swap_annuity,
+                                       option_maturity,
+                                       vol):
+        # raise AssertionError
+        if vol < 0.0:
+            with pytest.raises(AssertionError):
+                actual = target.black_swaption_cdf(
+                    init_swap_rate,
+                    option_strike,
+                    swap_annuity,
+                    option_maturity,
+                    vol)
+            return
+        else:
+            # double checking implimentation of formula
+            # because it is a bit complicated to generate test cases
+            expect = (1.0
+                      + function.black_payers_swaption_value_fprime_by_strike(
+                          init_swap_rate,
+                          option_strike,
+                          swap_annuity,
+                          option_maturity,
+                          vol) / swap_annuity)
+
+            actual = target.black_swaption_cdf(
+                init_swap_rate,
+                option_strike,
+                swap_annuity,
+                option_maturity,
+                vol)
+            assert expect == approx(actual)
+
+    @pytest.mark.parametrize(
+        "init_swap_rate, option_strike, swap_annuity, option_maturity, vol",
+        [
+            # vol < 0 raise AssertionError
+            (1.1, 2.1, 1.2, 1.3, -0.1),
+            # otherwise
+            (1.1, 2.1, 1.2, 1.3, 0.1),
+        ])
+    def test_black_payers_swaption_pdf(self,
+                                       init_swap_rate,
+                                       option_strike,
+                                       swap_annuity,
+                                       option_maturity,
+                                       vol):
+        # raise AssertionError
+        if vol < 0.0:
+            with pytest.raises(AssertionError):
+                actual = target.black_swaption_pdf(
+                    init_swap_rate,
+                    option_strike,
+                    swap_annuity,
+                    option_maturity,
+                    vol)
+            return
+        else:
+            # double checking implimentation of formula
+            # because it is a bit complicated to generate test cases
+            expect = (function.black_payers_swaption_value_fhess_by_strike(
+                init_swap_rate,
+                option_strike,
+                swap_annuity,
+                option_maturity,
+                vol) / swap_annuity)
+
+            actual = target.black_swaption_pdf(
+                init_swap_rate,
+                option_strike,
+                swap_annuity,
+                option_maturity,
+                vol)
+            assert expect == approx(actual)

--- a/mafipy/function/tests/test_black.py
+++ b/mafipy/function/tests/test_black.py
@@ -306,6 +306,168 @@ class TestBlack(object):
         assert expect == approx(actual)
 
     # -------------------------------------------------------------------------
+    # black payer's/reciever's swaption greeks
+    # -------------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "init_swap_rate, option_strike, swap_annuity, option_maturity, vol",
+        [
+            # vol < 0 raise AssertionError
+            (1.0, 2.0, 1.0, 1.0, -0.1),
+            # maturity < 0
+            (1.0, 2.0, 1.0, -1.0, 0.1),
+            # otherwise
+            (1.1, 1.2, 1.3, 1.4, 0.1),
+        ])
+    def test_model_black_payers_swaption_delta(self,
+                                               init_swap_rate,
+                                               option_strike,
+                                               swap_annuity,
+                                               option_maturity,
+                                               vol):
+        # raise AssertionError
+        if vol < 0.0:
+            with pytest.raises(AssertionError):
+                actual = target.black_payers_swaption_delta(
+                    init_swap_rate,
+                    option_strike,
+                    swap_annuity,
+                    option_maturity,
+                    vol)
+            return
+        elif option_maturity < 0.0 or np.isclose(option_maturity, 0.0):
+            expect = 0.0
+            actual = target.black_payers_swaption_delta(
+                init_swap_rate,
+                option_strike,
+                swap_annuity,
+                option_maturity,
+                vol)
+            assert expect == approx(actual)
+        else:
+            shock = 1e-6
+            value_plus = function.black_payers_swaption_value(
+                init_swap_rate + shock, option_strike, swap_annuity,
+                option_maturity, vol)
+            value_minus = function.black_payers_swaption_value(
+                init_swap_rate - shock, option_strike, swap_annuity,
+                option_maturity, vol)
+            expect = (value_plus - value_minus) / (2.0 * shock)
+
+            actual = target.black_payers_swaption_delta(
+                init_swap_rate,
+                option_strike,
+                swap_annuity,
+                option_maturity,
+                vol)
+            assert expect == approx(actual)
+
+    @pytest.mark.parametrize(
+        "init_swap_rate, option_strike, swap_annuity, option_maturity, vol",
+        [
+            # vol < 0 raise AssertionError
+            (1.0, 2.0, 1.0, 1.0, -0.1),
+            # maturity < 0
+            (1.0, 2.0, 1.0, -1.0, 0.1),
+            # otherwise
+            (1.1, 1.2, 1.3, 1.4, 0.1),
+        ])
+    def test_model_black_payers_swaption_vega(self,
+                                              init_swap_rate,
+                                              option_strike,
+                                              swap_annuity,
+                                              option_maturity,
+                                              vol):
+        # raise AssertionError
+        if vol < 0.0:
+            with pytest.raises(AssertionError):
+                actual = target.black_payers_swaption_vega(
+                    init_swap_rate,
+                    option_strike,
+                    swap_annuity,
+                    option_maturity,
+                    vol)
+            return
+        elif option_maturity < 0.0 or np.isclose(option_maturity, 0.0):
+            expect = 0.0
+            actual = target.black_payers_swaption_vega(
+                init_swap_rate,
+                option_strike,
+                swap_annuity,
+                option_maturity,
+                vol)
+            assert expect == approx(actual)
+        else:
+            shock = 1e-6
+            value_plus = function.black_payers_swaption_value(
+                init_swap_rate, option_strike, swap_annuity,
+                option_maturity, vol + shock)
+            value_minus = function.black_payers_swaption_value(
+                init_swap_rate, option_strike, swap_annuity,
+                option_maturity, vol - shock)
+            expect = (value_plus - value_minus) / (2.0 * shock)
+
+            actual = target.black_payers_swaption_vega(
+                init_swap_rate,
+                option_strike,
+                swap_annuity,
+                option_maturity,
+                vol)
+            assert expect == approx(actual)
+
+    @pytest.mark.parametrize(
+        "init_swap_rate, option_strike, swap_annuity, option_maturity, vol",
+        [
+            # vol < 0 raise AssertionError
+            (1.0, 2.0, 1.0, 1.0, -0.1),
+            # maturity < 0
+            (1.0, 2.0, 1.0, -1.0, 0.1),
+            # otherwise
+            (1.1, 1.2, 1.3, 1.4, 0.1),
+        ])
+    def test_model_black_payers_swaption_volga(self,
+                                               init_swap_rate,
+                                               option_strike,
+                                               swap_annuity,
+                                               option_maturity,
+                                               vol):
+        # raise AssertionError
+        if vol < 0.0:
+            with pytest.raises(AssertionError):
+                actual = target.black_payers_swaption_volga(
+                    init_swap_rate,
+                    option_strike,
+                    swap_annuity,
+                    option_maturity,
+                    vol)
+            return
+        elif option_maturity < 0.0 or np.isclose(option_maturity, 0.0):
+            expect = 0.0
+            actual = target.black_payers_swaption_volga(
+                init_swap_rate,
+                option_strike,
+                swap_annuity,
+                option_maturity,
+                vol)
+            assert expect == approx(actual)
+        else:
+            shock = 1e-6
+            value_plus = target.black_payers_swaption_vega(
+                init_swap_rate, option_strike, swap_annuity,
+                option_maturity, vol + shock)
+            value_minus = target.black_payers_swaption_vega(
+                init_swap_rate, option_strike, swap_annuity,
+                option_maturity, vol - shock)
+            volga_diff = (value_plus - value_minus) / (2.0 * shock)
+
+            volga_analytic = target.black_payers_swaption_volga(
+                init_swap_rate,
+                option_strike,
+                swap_annuity,
+                option_maturity,
+                vol)
+            assert volga_diff == approx(volga_analytic)
+
+    # -------------------------------------------------------------------------
     # black payer's/reciever's swaption distribution
     # -------------------------------------------------------------------------
     @pytest.mark.parametrize(

--- a/mafipy/function/tests/test_black_scholes.py
+++ b/mafipy/function/tests/test_black_scholes.py
@@ -387,10 +387,10 @@ class TestBlackScholes(object):
     @pytest.mark.parametrize(
         "underlying, strike, rate, maturity, vol, today",
         [
-            # maturity < 0 raise AssertionError
-            (1.0, 2.0, 1.0, -1.0, 0.1, 0.0),
             # vol < 0 raise AssertionError
             (1.0, 2.0, 1.0, 1.0, -0.1, 0.0),
+            # maturity < 0, returns 0
+            (1.0, 2.0, 1.0, -1.0, 0.1, 0.0),
             # otherwise
             (1.0, 2.0, 1.0, 1.0, 0.1, 0.0),
         ])
@@ -398,10 +398,15 @@ class TestBlackScholes(object):
             self, underlying, strike, rate, maturity, vol, today):
 
         # raise AssertionError
-        if maturity < 0.0 or vol < 0.0:
+        if vol < 0.0:
             with pytest.raises(AssertionError):
                 actual = target.black_scholes_call_delta(
                     underlying, strike, rate, maturity, vol)
+            return
+        elif maturity < 0.0:
+            actual = target.black_scholes_call_delta(
+                underlying, strike, rate, maturity, vol)
+            assert 0.0 == approx(actual)
         else:
             # double checking implimentation of formula
             # because it is a bit complicated to generate test cases
@@ -444,10 +449,10 @@ class TestBlackScholes(object):
     @pytest.mark.parametrize(
         "underlying, strike, rate, maturity, vol, today",
         [
-            # maturity < 0 raise AssertionError
-            (1.1, 2.1, 1.2, -1.3, 0.1, 0.0),
             # vol < 0 raise AssertionError
             (1.1, 2.2, 1.3, 1.4, -0.1, 0.0),
+            # maturity < 0 returns 0
+            (1.1, 2.1, 1.2, -1.3, 0.1, 0.0),
             # otherwise
             (1.1, 2.2, 1.3, 1.4, 0.1, 0.0),
         ])
@@ -455,10 +460,14 @@ class TestBlackScholes(object):
             self, underlying, strike, rate, maturity, vol, today):
 
         # raise AssertionError
-        if maturity < 0.0 or vol < 0.0:
+        if vol < 0.0:
             with pytest.raises(AssertionError):
                 actual = target.black_scholes_call_vega(
                     underlying, strike, rate, maturity, vol)
+        elif maturity < 0.0:
+            actual = target.black_scholes_call_vega(
+                underlying, strike, rate, maturity, vol)
+            assert 0.0 == approx(actual)
         else:
             # double checking implimentation of formula
             # because it is a bit complicated to generate test cases

--- a/mafipy/function/tests/test_black_scholes.py
+++ b/mafipy/function/tests/test_black_scholes.py
@@ -388,11 +388,11 @@ class TestBlackScholes(object):
         "underlying, strike, rate, maturity, vol, today",
         [
             # vol < 0 raise AssertionError
-            (1.0, 2.0, 1.0, 1.0, -0.1, 0.0),
+            (1.1, 1.2, 0.2, 1.3, -0.1, 0.0),
             # maturity < 0, returns 0
-            (1.0, 2.0, 1.0, -1.0, 0.1, 0.0),
+            (1.1, 1.2, 0.2, -1.3, 0.1, 0.0),
             # otherwise
-            (1.0, 2.0, 1.0, 1.0, 0.1, 0.0),
+            (1.1, 1.2, 0.2, 1.3, 0.1, 0.0),
         ])
     def test_black_scholes_call_delta(
             self, underlying, strike, rate, maturity, vol, today):
@@ -408,10 +408,12 @@ class TestBlackScholes(object):
                 underlying, strike, rate, maturity, vol)
             assert 0.0 == approx(actual)
         else:
-            # double checking implimentation of formula
-            # because it is a bit complicated to generate test cases
-            d1 = target.func_d1(underlying, strike, rate, maturity, vol)
-            expect = scipy.stats.norm.cdf(d1)
+            shock = 1e-6
+            value_plus = function.black_scholes_call_value(
+                underlying + shock, strike, rate, maturity, vol)
+            value_minus = function.black_scholes_call_value(
+                underlying - shock, strike, rate, maturity, vol)
+            expect = (value_plus - value_minus) / (2.0 * shock)
 
             actual = target.black_scholes_call_delta(
                 underlying, strike, rate, maturity, vol)
@@ -420,27 +422,28 @@ class TestBlackScholes(object):
     @pytest.mark.parametrize(
         "underlying, strike, rate, maturity, vol, today",
         [
-            # maturity < 0 raise AssertionError
-            (1.0, 2.0, 1.0, -1.0, 0.1, 0.0),
             # vol < 0 raise AssertionError
-            (1.0, 2.0, 1.0, 1.0, -0.1, 0.0),
+            (1.1, 1.2, 0.2, 1.3, -0.1, 0.0),
+            # maturity < 0 returns 0
+            (1.1, 1.2, 0.2, -1.3, 0.1, 0.0),
             # otherwise
-            (1.0, 2.0, 1.0, 1.0, 0.1, 0.0),
+            (1.1, 1.2, 0.2, 1.3, 0.1, 0.0),
         ])
     def test_black_scholes_call_gamma(
             self, underlying, strike, rate, maturity, vol, today):
 
         # raise AssertionError
-        if maturity < 0.0 or vol < 0.0:
+        if vol < 0.0:
             with pytest.raises(AssertionError):
                 actual = target.black_scholes_call_gamma(
                     underlying, strike, rate, maturity, vol)
         else:
-            # double checking implimentation of formula
-            # because it is a bit complicated to generate test cases
-            d1 = target.func_d1(underlying, strike, rate, maturity, vol)
-            denominator = (underlying ** 2) * vol * math.sqrt(maturity)
-            expect = -scipy.stats.norm.pdf(d1) / denominator
+            shock = 1e-6
+            value_plus = function.black_scholes_call_delta(
+                underlying + shock, strike, rate, maturity, vol)
+            value_minus = function.black_scholes_call_delta(
+                underlying - shock, strike, rate, maturity, vol)
+            expect = (value_plus - value_minus) / (2.0 * shock)
 
             actual = target.black_scholes_call_gamma(
                 underlying, strike, rate, maturity, vol)
@@ -519,11 +522,11 @@ class TestBlackScholes(object):
         "underlying, strike, rate, maturity, vol, today",
         [
             # maturity < 0 raise AssertionError
-            (1.0, 2.0, 1.0, -1.0, 0.1, 0.0),
+            (1.1, 1.2, 0.2, -1.3, 0.1, 0.0),
             # vol < 0 raise AssertionError
-            (1.0, 2.0, 1.0, 1.0, -0.1, 0.0),
+            (1.1, 1.2, 0.2, 1.3, -0.1, 0.0),
             # otherwise
-            (1.0, 2.0, 1.0, 1.0, 0.1, 0.0),
+            (1.1, 1.2, 0.2, 1.3, 0.1, 0.0),
         ])
     def test_black_scholes_call_theta(
             self, underlying, strike, rate, maturity, vol, today):
@@ -534,15 +537,12 @@ class TestBlackScholes(object):
                 actual = target.black_scholes_call_theta(
                     underlying, strike, rate, maturity, vol, today)
         else:
-            # double checking implimentation of formula
-            # because it is a bit complicated to generate test cases
-            norm = scipy.stats.norm
-            time = maturity - today
-            d1 = target.func_d1(underlying, strike, rate, time, vol)
-            term1 = underlying * norm.pdf(d1) * vol / (2.0 * math.sqrt(time))
-            d2 = target.func_d2(underlying, strike, rate, time, vol)
-            term2 = rate * math.exp(-rate * time) * strike * norm.cdf(d2)
-            expect = -term1 - term2
+            shock = 1e-6
+            value_plus = function.black_scholes_call_value(
+                underlying, strike, rate, maturity, vol, today + shock)
+            value_minus = function.black_scholes_call_value(
+                underlying, strike, rate, maturity, vol, today - shock)
+            expect = (value_plus - value_minus) / (2.0 * shock)
 
             actual = target.black_scholes_call_theta(
                 underlying, strike, rate, maturity, vol, today)
@@ -552,11 +552,11 @@ class TestBlackScholes(object):
         "underlying, strike, rate, maturity, vol, today",
         [
             # maturity < 0 raise AssertionError
-            (1.0, 2.0, 1.0, -1.0, 0.1, 0.0),
+            (1.1, 1.2, 0.2, -1.3, 0.1, 0.0),
             # vol < 0 raise AssertionError
-            (1.0, 2.0, 1.0, 1.0, -0.1, 0.0),
+            (1.1, 1.2, 0.2, 1.3, -0.1, 0.0),
             # otherwise
-            (1.0, 2.0, 1.0, 1.0, 0.1, 0.0),
+            (1.1, 1.2, 0.2, 1.3, 0.1, 0.0),
         ])
     def test_black_scholes_call_rho(
             self, underlying, strike, rate, maturity, vol, today):
@@ -567,15 +567,50 @@ class TestBlackScholes(object):
                 actual = target.black_scholes_call_rho(
                     underlying, strike, rate, maturity, vol, today)
         else:
-            # double checking implimentation of formula
-            # because it is a bit complicated to generate test cases
-            norm = scipy.stats.norm
-            time = maturity - today
-            d2 = target.func_d2(underlying, strike, rate, time, vol)
-            expect = time * math.exp(-rate * time) * strike * norm.cdf(d2)
+            shock = 1e-6
+            value_plus = function.black_scholes_call_value(
+                underlying, strike, rate + shock, maturity, vol, today)
+            value_minus = function.black_scholes_call_value(
+                underlying, strike, rate - shock, maturity, vol, today)
+            expect = (value_plus - value_minus) / (2.0 * shock)
 
             actual = target.black_scholes_call_rho(
                 underlying, strike, rate, maturity, vol, today)
+            assert expect == approx(actual)
+
+    @pytest.mark.parametrize(
+        "underlying, strike, rate, maturity, vol",
+        [
+            # vol < 0 raise AssertionError
+            (1.1, 1.2, 0.3, 1.4, -0.1),
+            # maturity <= 0 return 0
+            (1.1, 1.2, 0.2, -1.3, 0.1),
+            # otherwise
+            (1.1, 1.2, 0.3, 1.4, 0.1),
+        ])
+    def test_black_scholes_call_vega_fprime_by_strike(
+            self, underlying, strike, rate, maturity, vol):
+
+        # raise AssertionError
+        if vol < 0.0:
+            with pytest.raises(AssertionError):
+                actual = target.black_scholes_call_vega_fprime_by_strike(
+                    underlying, strike, rate, maturity, vol)
+        elif maturity <= 0.0:
+            expect = 0
+            actual = target.black_scholes_call_vega_fprime_by_strike(
+                underlying, strike, rate, maturity, vol)
+            assert expect == approx(actual)
+        else:
+            shock = 1e-6
+            value_plus = function.black_scholes_call_vega(
+                underlying, strike + shock, rate, maturity, vol)
+            value_minus = function.black_scholes_call_vega(
+                underlying, strike - shock, rate, maturity, vol)
+            expect = (value_plus - value_minus) / (2.0 * shock)
+
+            actual = target.black_scholes_call_vega_fprime_by_strike(
+                underlying, strike, rate, maturity, vol)
             assert expect == approx(actual)
 
     # -------------------------------------------------------------------------

--- a/mafipy/function/tests/test_sabr.py
+++ b/mafipy/function/tests/test_sabr.py
@@ -575,3 +575,54 @@ class TestSabr(object):
             alpha, beta, rho, nu)
 
         assert delta_analytic == approx(delta_diff, rel=5e-3)
+
+    # -------------------------------------------------------------------------
+    # SABR distribution
+    # -------------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "init_swap_rate, option_strike, option_maturity,\
+        alpha, beta, rho, nu", [
+            (0.0357, 0.03, 2.0, 0.036, 0.5, -0.25, 0.35)
+        ])
+    def test_model_sabr_cdf(
+            self, init_swap_rate, option_strike, option_maturity,
+            alpha, beta, rho, nu):
+        shock = 1e-6
+        value_plus = target.sabr_payers_swaption_value(
+            init_swap_rate, option_strike + shock, 1.0,
+            option_maturity, alpha, beta, rho, nu)
+        value_minus = target.sabr_payers_swaption_value(
+            init_swap_rate, option_strike - shock, 1.0,
+            option_maturity, alpha, beta, rho, nu)
+        value_diff = (value_plus - value_minus) / (2.0 * shock)
+        cdf_diff = 1.0 + value_diff
+
+        cdf_analytic = target.sabr_cdf(
+            init_swap_rate, option_strike, option_maturity,
+            alpha, beta, rho, nu)
+
+        assert cdf_analytic == approx(cdf_diff)
+
+    @pytest.mark.parametrize(
+        "init_swap_rate, option_strike, option_maturity,\
+        alpha, beta, rho, nu", [
+            (0.0357, 0.03, 2.0, 0.036, 0.5, -0.25, 0.35)
+        ])
+    def test_model_sabr_pdf(
+            self, init_swap_rate, option_strike, option_maturity,
+            alpha, beta, rho, nu):
+        shock = 1e-6
+        value_plus = target.sabr_cdf(
+            init_swap_rate, option_strike + shock, option_maturity,
+            alpha, beta, rho, nu)
+        value_minus = target.sabr_cdf(
+            init_swap_rate, option_strike - shock, option_maturity,
+            alpha, beta, rho, nu)
+        value_diff = (value_plus - value_minus) / (2.0 * shock)
+        pdf_diff = value_diff
+
+        pdf_analytic = target.sabr_pdf(
+            init_swap_rate, option_strike, option_maturity,
+            alpha, beta, rho, nu)
+
+        assert pdf_analytic == approx(pdf_diff, rel=5e-5)


### PR DESCRIPTION
This issue introduces probability density function (p.d.f.) and Cumulative distribution function (c.d.f) of underlying under SABR model. 
p.d.f. and c.d.f. are derived by derivative of call option with respect to strike.