### PR TITLE
Update code climate version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 
 # coverage
 /.coverage
+/coverage.xml
 
 
 # cython
@@ -28,6 +29,10 @@
 
 # travis cli
 .rbenv-gemsets
+Gemfile
+Gemfile.lock
+/vendor
+/.bundle
 
 # OSX
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
   global:
   # CODECLIMATE_REPO_TOKEN=<token>
   - secure: E94zYUHEXpRwHTqv/mq4C+i8GrrY2xFWIfkvLgWEYZ10Abw6PtJDssS3E1hrk3pD1t0YxsN5UrO9nSSFLNZNwC24VJKhC2h7+PItgsxH8PLRkumyVjBQftLqjO5Cgqknxy8Jtm8k7d8v0C5bUPzETK8kG8f0JofKMOJ/Y2CgAdxntkIu7OkzxZpsakJPUckUWhB/WMR6CGf681Tsa6ntEbsJnbm+sEyuPLGZeFOymY0UfS5zaLhBpXeSNfxDO53ewDHDJ9tGZ2H/WNaNs6FDyPLzOOUSCVgPX+v7LPi+h2aqV+2qWT3MhChZQyBomGen5NpWRuBunDKHNho6TEQL/HRTmPXOieYbRutjcdgCrCbCC5JQ7DL674virjemMw/k0mVCHycvX6AE99R2Gd8yeIG1pBnBMWpWlcKXnzA9EAkDkoxcoUStLwF3np1xjqNYxfegZYzBSzyL/Iyam7ltesOh3bQ8uzuxt90jI8dik3oOILmXAT+mxc04yoHjuO/DIqEMX8T9tofgk37/rnYaiuFM1ToRVG1ozuhVlDFRIKnLidbwDUFb4fqYC7RSvElC5Iz51Pe35bZHNDIikk4Drm4lBZ7CmyJFCfspDaMdBJJTBfNW1q2OSKdRC2YnmQ+qyJApZlyCFlIrxH6Ewk/hF002H7cxD59hmdSWnivsZMM=
+  # CC_TEST_REPORTER_ID=<token>
+  - secure: "iomMx3XJ60WKz9LKGk6J4ZYe8H1xxkQ8AxrWeRtYuSmR1ylBsIbAg5aPd5bnkDFjXwetPOwKBng4K+e5jbMtfO7447KUB7rWPZnbfTPotZyx3aYZnZXdXphSXzUNhWmSjWQQoOM93gK3wcht/gdhdcCrAYv4td+HY4KLVxtswLCiFWzPsW5el8saEh3mR1tD7wBvESzTWDNxtCv7yDhmp6U/8Irvv8nFR5v5P+71Har8T+eh3cI+uEtRxuX8T0+MKGWOpH0GjFWjiqAaIsZhdV/b7zCEP369ojtgaFjXYEIZroYKftJ2swHG00Za7jeKFiY+/+8Vaa1kG+6IJ01TXbr/0Aw+OIscn3zeapq9/B9eCkqXfc2pmOa8QHR8XPQwGdykgUijRuvfKFconD6FrWSKEG/lkk+zSsDjZBHePcIbcCZ0yqzu+yutyHqsS2BXTsRWOq4TQzgv/PDzAvflsW5TWPH3TDE/R8/StLdr36+6CbQC3LB2aqk5dPbsoAfon/oJRve3DYwkQS3Y2t4sR1OvZoh39fhv389sHuDhvA7Hni04y7D0GkgsQVItb/iUCMoV7H7cTzr26mC2bBklCOQkzNIuwj7OdH+U53hvOw8nm2xbslvVIiXNlATMpbE0iS7ZrcGOtK35Ip6SnlZO3uZvk91znUYMIbukOxyT2tE="
 matrix:
   include:
   - python: '2.7'
@@ -25,7 +27,7 @@ before_install:
 - echo ${PATH}
 - python --version
 install: bash ci/travis/install.sh
-script: python setup.py test
+script: bash ci/travis/test.sh
 after_success: bash ci/travis/after_success.sh
 notifications:
   slack:

--- a/ci/travis/after_success.sh
+++ b/ci/travis/after_success.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 set -e
-set -x
 
 if [ "${CODECLIMATE_COVERAGE_REPORT}" == "true" ]; then
-  set +x
-  codeclimate-test-reporter --token ${CODECLIMATE_REPO_TOKEN}
+  echo "Executing /usr/bin/cc-test-reporter after-build"
+  /usr/bin/cc-test-reporter after-build \
+      --coverage-input-type coverage.py \
+      --id ${CC_TEST_REPORTER_ID}
 fi

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -30,7 +30,15 @@ else
 
   # executing only in python 3.5
   if [ "${CODECLIMATE_COVERAGE_REPORT}" = "true" ]; then
-    pip install codeclimate-test-reporter
+    #
+    # install cc-test-reporter
+    #
+    mkdir -p $HOME/.cache/codeclimate
+    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > $HOME/.cache/codeclimate/cc-test-reporter
+    chmod +x $HOME/.cache/codeclimate/cc-test-reporter
+    ln -s $HOME/.cache/codeclimate/cc-test-reporter /usr/bin/cc-test-reporter
+    # run
+    /usr/bin/cc-test-reporter before-build
   fi
 
 fi

--- a/ci/travis/test.sh
+++ b/ci/travis/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+echo 'List files from cached directories'
+echo 'pip:'
+ls $HOME/.cache/pip
+ls $HOME/.cache
+
+if [ "${SKIP_TESTS}" == "true" ]; then
+    echo "No need to build mafipy when not running the tests"
+else
+  # executing only in python 3.5
+  if [ "${CODECLIMATE_COVERAGE_REPORT}" = "true" ]; then
+    python setup.py test --cov-report=xml,term
+  else
+    python setup.py test
+  fi
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New code climate CLI tool was released and the old one was deprecated.
See [codeclimate/python\-test\-reporter: Uploads Python test coverage data to Code Climate https://codeclimate\.com](https://github.com/codeclimate/python-test-reporter)
For this reason, the way to send coverage report was changed so that coverage reports didn't work propely in master branch.
In this PR, we migrate the old code climate reporter to the new one.  The new reporter requires coverage reports as `xml` file. To support `xml` output, we add `python setup.py test` command a new option `--cov-report`, which passes arugments to `--cov-report` option in `pytest-cov`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> 
<!--- If it fixes an open issue, please link to the issue here. -->
Codeclimate coverage reports was not available because of the change related to codeclimate.

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. --> 
I've locally run lines of code;

```
export CC_TEST_REPORTER_ID=<token>
./cc-test-reporter before-build
python setup.py test --cov-report=xml,term
./cc-test-reporter after-build --coverage-input-type coverage.py
```

See `.travis.yml` for more details.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests have been passed.
